### PR TITLE
docs: add PhosKinTime multimodal input audit

### DIFF
--- a/docs/phoskintime_jaxopt_diffrax_networkmodel_protwise_audit.md
+++ b/docs/phoskintime_jaxopt_diffrax_networkmodel_protwise_audit.md
@@ -1,0 +1,816 @@
+# PhosKinTime JAXopt/Diffrax Migration Audit for networkmodel and protwise
+
+## 1. Purpose
+
+This is an audit-only planning document for a future migration of PhosKinTime's `networkmodel` and `protwise` workflows to a JAX/JAXopt/Diffrax-based optimization and ODE-solving stack.
+
+The target future architecture is:
+
+- JAX float64 enabled globally before numerical computation.
+- Differentiable model, solver, observable extraction, and loss paths written with `jax.numpy`/JAX-compatible operations.
+- JAXopt-based single-objective optimization.
+- Diffrax-based ODE integration with stiff/semi-stiff solver candidates `diffrax.Kvaerno4` and `diffrax.Kvaerno5`.
+- Dynamic mRNA/protein/phospho loss inclusion compatible with the previous multi-modal audit.
+- Conversion to NumPy/Pandas only outside the differentiable computation path, specifically at data loading, plotting, exporting, dashboard, and reporting boundaries.
+
+This document does not implement the migration. It identifies current SciPy/pymoo/Numba/Optuna/multi-objective/ODE dependencies and describes how later implementation should replace them while preserving the existing configuration interface and biological model structure.
+
+## 2. Non-goals
+
+- No code changes are made in this audit.
+- No configuration schema changes are proposed as mandatory.
+- No KinOpt or TFOpt work is included.
+- No unrelated refactor is proposed as a prerequisite.
+- No implementation is included yet.
+- No change to the biological model structure is proposed.
+- No Python files, tests, configuration files, notebooks, dashboards, or scripts are edited in this audit.
+- No dashboard/script/notebook edits should happen until the JAXopt/Diffrax core migration is planned and tested.
+- No separate data-type-specific models should be introduced; the existing state structure should remain the source of mRNA, protein, and phospho observables.
+
+## 3. Relationship to Previous Multi-Modal Audit
+
+This audit refines `docs/phoskintime_multimodal_input_audit.md`, which planned future support for all seven combinations of mRNA, protein, and phospho observations. That previous audit recommended an internal data-mode object and dynamic loss assembly. The JAXopt/Diffrax migration changes the optimization target: instead of producing dynamic multi-objective vectors or retaining the current three-objective Pareto front, the future objective must return one scalar JAX value.
+
+The refined rule is:
+
+```text
+L_total =
+    w_mrna    * L_mrna      if mRNA observations are active
+  + w_protein * L_protein   if protein observations are active
+  + w_phospho * L_phospho   if phospho observations are active
+  + regularization terms
+  + constraint penalties only when projection/reparameterization is unsuitable
+```
+
+Unavailable data layers must be skipped inside the scalar objective. They must not be represented as fake zeros, NaNs, empty Pandas frames inside JIT, or inactive pymoo objectives. The model remains structurally the same across all modes; only observable selection and scalar loss terms are mode-aware.
+
+The previous audit's `DataMode`/`available_layers` concept should become a static, precomputed metadata object used to construct fixed-shape JAX arrays and layer masks before optimization. JAX functions should receive numeric masks/weights, not strings, sets, Pandas objects, or dynamically changing Python containers.
+
+## 4. Files and Folders Inspected
+
+KinOpt and TFOpt paths, files, tests, configs, and modules were intentionally excluded.
+
+| File/folder | Role in this audit |
+|---|---|
+| `docs/phoskintime_multimodal_input_audit.md` | Previous audit read first; this document refines its multimodal plan for JAXopt single-objective/Diffrax migration. |
+| `networkmodel/` | Main global coupled ODE workflow. Contains data loading, model topology, ODE solving, loss, pymoo/Optuna optimization, exports, dashboard bundle, dashboard app, refinement, hyperparameter scan, and sensitivity. |
+| `networkmodel/runner.py` | Main global model orchestration. Imports Pymoo algorithms/operators/termination, constructs `GlobalODE_MOO`, runs Pymoo or Optuna, writes Pareto artifacts, selects picked solution, exports plots/tables, and logs final summaries. |
+| `networkmodel/io.py` | Loads kinase/TF networks and RNA/MS observations into `df_prot`, `df_pho`, and `df_rna`. Future migration should keep Pandas loading outside JAX and emit numeric arrays for JAX core. |
+| `networkmodel/network.py` | Defines `Index`, `KinaseInput`, and `System`; currently stores mutable NumPy arrays and Numba/Scipy argument buffers. Must be split into static metadata and JAX numeric state/parameter containers. |
+| `networkmodel/models.py` | Numba RHS kernels for distributive/sequential/combinatorial/saturating models. Future equivalent RHS functions must be pure JAX. |
+| `networkmodel/simulate.py` | Current ODE wrapper using `scipy.integrate.odeint` or custom Numba solver. Must be replaced by centralized Diffrax solve functions. |
+| `networkmodel/lossfn.py` | Numba loss kernels returning protein/RNA/phospho loss sums. Future loss must be pure JAX and scalar-composed. |
+| `networkmodel/cache.py` | Pre-indexes Pandas observations to numeric arrays. This is a good boundary for converting loaded data to fixed-shape JAX-ready arrays and masks. |
+| `networkmodel/optproblem.py` | Pymoo `ElementwiseProblem` wrapper with fixed `n_obj=3`. Must be replaced by a JAXopt scalar objective wrapper. |
+| `networkmodel/params.py` | Flat parameter packing/unpacking and softplus transforms. Must become JAX-compatible and projection-aware. |
+| `networkmodel/utils.py` | Config dataclass, scaling, bounds, Numba helpers, and objective-selection helpers. Needs JAX-safe separation and config-backward-compat mapping. |
+| `networkmodel/optuna_solver.py` | Alternative Optuna solver. Must be removed, deprecated, or converted to a JAXopt-compatible single-objective runner; current Optuna result compatibility should be replaced. |
+| `networkmodel/refine.py` | Pymoo-based refinement of Pareto fronts. Must be replaced with JAXopt restart/continuation logic or removed/deprecated. |
+| `networkmodel/scan.py` | Optuna + Pymoo hyperparameter scan. Must be replaced with single-objective weight-scan logic or optional non-differentiated outer-loop search. |
+| `networkmodel/export.py` | Exports Pareto fronts, trajectories, goodness-of-fit plots, residuals, parameter uncertainty, correlations, convergence video, S-rates. Heavily assumes `res.X`, `res.F`, Pareto sets, and three objective columns. |
+| `networkmodel/dashboard_bundle.py` | Serializes Pymoo/Optuna-like result objects and data frames into `dashboard_bundle.pkl`. Must store a JAXopt result summary instead. |
+| `networkmodel/dashboard_app.py` | Streamlit dashboard that displays Pareto front, fixed three objective columns, picked objectives, and prediction files. Must be single-objective and mode-aware later; not edited in this audit. |
+| `networkmodel/analysis.py` | Uses `simulate_odeint()` for steady-state simulation. Must route through Diffrax solver wrapper. |
+| `networkmodel/model_ivp.py` | Contains functions compatible with `scipy.integrate.solve_ivp`. Should be deprecated or ported to JAX RHS functions. |
+| `networkmodel/jacspeedup.py`, `networkmodel/solvers.py` | Numba/JIT custom solver and RHS/Jacobian acceleration. Must not be used in JAX-differentiated paths; likely replaced by Diffrax. |
+| `networkmodel/steadystate.py` | Builds data-derived initial conditions and analytic steady-state helpers. JAX migration must keep Pandas/dicts outside JAX and produce numeric JAX initial conditions. |
+| `protwise/` | Legacy/local per-gene ODE workflow. Currently uses SciPy `curve_fit`, SciPy `minimize` for initial conditions, and SciPy `odeint`. Must also migrate. |
+| `protwise/runner/main.py` | Legacy/local orchestration. Loads protein, phosphosite, and mRNA data; validates columns; runs per-gene estimation; saves plots/reports. |
+| `protwise/paramest/core.py` | Extracts per-gene arrays, calls `estimate_parameters()`, computes metrics, solves ODE, plots, sensitivity, knockout, and returns result dicts. |
+| `protwise/paramest/normest.py` | Main local parameter-estimation objective and `curve_fit` calls. Must be ported to JAX/JAXopt single-objective fitting. |
+| `protwise/paramest/toggle.py` | Dispatches parameter estimation; should dispatch to JAXopt implementation later. |
+| `protwise/models/distmod.py`, `protwise/models/succmod.py`, `protwise/models/randmod.py` | Local ODE model solvers using `scipy.integrate.odeint` and NumPy/Numba. Must be ported to JAX RHS + Diffrax. |
+| `protwise/steady/initdist.py`, `protwise/steady/initsucc.py`, `protwise/steady/initrand.py` | Use `scipy.optimize.minimize` with SLSQP constraints to compute steady-state initial conditions. Must become analytic/JAX root solve/projection-compatible. |
+| `protwise/plotting/plotting.py` | Downstream plotting that assumes NumPy arrays and fixed mRNA/protein/phospho slices. Should remain outside JAX but become mode-aware. |
+| `common/utils/display.py`, `common/utils/tables.py`, `common/frechet/distance.py` | Local output/report helpers and Frechet metric. Should remain outside differentiable core; any Numba metric use must not be in objective. |
+| `config_loader.py`, `config/config.py`, `config/constants.py`, `config/cli.py`, `config/logconf.py` | Existing config/CLI/logging surfaces. Must remain schema-compatible; map old optimizer/solver options internally. |
+| `scripts/*.py` | Standalone scripts. Several use Pymoo, `solve_ivp`, or `networkmodel.simulate_odeint`. They should not block core migration but need later reference cleanup or compatibility wrappers. |
+| `run_dashboard.py` | Dashboard launcher. No direct solver/optimizer logic, but dashboard content must change later. |
+| `README.md`, `PYPI_README.md`, `docs/Documentation/**/*.md`, `networkmodel/README.md` | Documentation contains old SciPy/pymoo/Pareto/multi-objective/evolution references that must be updated after code migration. |
+| Notebooks | No `.ipynb` files were found by `rg --files -g '*.ipynb'` outside excluded KinOpt/TFOpt paths during this audit. |
+
+## 5. Current networkmodel Architecture
+
+### Input loading
+
+- `networkmodel.runner.main()` parses CLI/default values for network paths, `--ms`, `--rna`, `--phospho`, prior files, output directory, optimizer, cores, lambdas, scan/refine/sensitivity, and solver choice.
+- `networkmodel.config` imports `load_config_toml("config.toml")` from `config_loader.py` and exposes module-level constants.
+- `networkmodel.io.load_data(args)` loads and normalizes:
+  - kinase network into `df_kin_clean`
+  - TF network into `df_tf_clean`
+  - optional prior alphas/betas from Excel files
+  - MS data from `args.ms`, split into protein rows (`df_prot`) and phosphosite rows (`df_pho`) by blank/nonblank `psite`
+  - RNA data from `args.rna` into `df_rna`
+- The previous multi-modal audit noted that `args.phospho` is parsed but current loading uses `args.ms` for phospho.
+
+### Preprocessing
+
+- `networkmodel.utils._normcols()` normalizes column names.
+- `networkmodel.utils.process_and_scale_raw_data()` handles wide `x1..xN` data and scaling methods.
+- `networkmodel.utils.normalize_fc_to_t0()` optionally normalizes protein/phospho to t=0.
+- `runner.main()` filters phospho rows to mechanistic `(protein, psite)` pairs in `df_kin`, constructs/filters `df_tf_model`, then filters observations to `idx.proteins`.
+- Time weights are created via `networkmodel.optproblem.build_weight_functions()` and added as `w` columns.
+
+### Model construction
+
+- `networkmodel.network.Index` maps protein/site names to state-vector offsets. Non-combinatorial layout is `[mRNA_i, protein_i, phosphosite_1, ...]`; combinatorial layout is `[mRNA_i, protein_state_0, ..., protein_state_2^n]`.
+- `networkmodel.network.KinaseInput` creates `Kmat` from protein observations and defaults to ones for missing kinase observations.
+- `networkmodel.buildmat.build_W_parallel()` creates `W_global`; `build_tf_matrix()` creates `tf_mat`.
+- `networkmodel.network.System` stores mutable NumPy arrays for parameters and packed sparse buffers used by Numba/Scipy solvers.
+- `defaults` in `runner.main()` initializes `c_k`, `A_i`, `B_i`, `C_i`, `D_i`, `Dp_i`, `E_i`, and `tf_scale`.
+
+### ODE solving
+
+- `networkmodel.simulate.simulate_odeint()` dispatches either to a custom Numba solver (`solve_custom`) or to SciPy `odeint` with `rhs_odeint` and `fd_jacobian_odeint` from `networkmodel.jacspeedup`.
+- `networkmodel.simulate.simulate_and_measure()` solves once over the union of requested protein/RNA/phospho time grids and converts results into Pandas prediction tables.
+- `networkmodel.analysis.simulate_until_steady()` also uses `simulate_odeint()`.
+
+### Objective construction
+
+- `networkmodel.cache.prepare_fast_loss_data()` maps observations to integer arrays and weights for protein/RNA/phospho losses.
+- `networkmodel.lossfn.LOSS_FN` dispatches to Numba kernels `loss_function_noncomb()` or `loss_function_comb()` based on model type.
+- `networkmodel.optproblem.GlobalODE_MOO._evaluate()` unpacks parameters, updates the mutable `System`, solves ODEs, computes three raw losses, normalizes them, applies lambdas, adds prior regularization to each objective, and returns a length-3 objective vector.
+
+### Optimizer setup
+
+- The Pymoo path constructs `GlobalODE_MOO`, reference directions via `get_reference_directions()`, `UNSGA3`, `SBX`, `PM`, `LHS`, and `DefaultMultiObjectiveTermination`, then calls `pymoo.optimize.minimize()`.
+- The Optuna path calls `networkmodel.optuna_solver.run_optuna_solver()`, which wraps an Optuna multi-objective result into an `OptunaResult` with `.X` and `.F`.
+- Hyperparameter scan (`networkmodel.scan`) combines Optuna outer trials with Pymoo inner UNSGA3 runs.
+- Refinement (`networkmodel.refine`) creates refined Pymoo populations and reruns UNSGA3.
+
+### Constraints/bounds
+
+- `networkmodel.params.init_raw_params()` packs parameter arrays into a flat NumPy vector and maps physical bounds into raw softplus space.
+- `networkmodel.params.unpack_params()` applies softplus to raw parameters, enforcing positivity.
+- `networkmodel.utils.calculate_bio_bounds()` computes custom bounds from topology/data heuristics.
+- Pymoo `xl`/`xu` are raw-space box constraints.
+- No current networkmodel alpha/beta simplex constraint exists inside the global optimizer. Kinase/TF prior alpha/beta values are loaded from excluded upstream result files and used as priors/weights, not optimized directly in `networkmodel`.
+
+### Result extraction, plotting, saving, reporting
+
+- `runner.main()` saves `pymoo_optimization_result.pkl` or `optuna_optimization_result.pkl`, `pareto_X.npy`, `pareto_F.npy`, `pareto_F.csv`, `pareto_front.xlsx`, `fitted_params_picked.json`, `picked_objectives.json`, prediction CSVs, plots, residuals, parameter distributions, S-rate files, and a dashboard bundle.
+- `networkmodel.export.*` functions assume Pymoo-like `.X`, `.F`, Pareto sets, and often fixed columns `prot_mse`, `rna_mse`, `phospho_mse`.
+- `networkmodel.dashboard_app.py` displays a 3D Pareto front and fixed three objective columns.
+
+## 6. Current protwise Architecture
+
+### Input loading
+
+- `protwise.runner.main` uses `config.config.parse_args()` and `extract_config()`.
+- It reads protein data with `pd.read_csv(config['input_excel_protein'])`.
+- It reads phosphosite data from `pd.read_excel(config['input_excel_psite'], sheet_name='Estimated')`.
+- It reads mRNA data from `pd.read_excel(config['input_excel_rna'], sheet_name='Estimated')`.
+- It validates fixed columns: protein/phospho collectively require `Gene`, `Psite`, `x1..x14`; mRNA requires `mRNA`, `x1..x9`.
+- It processes only the intersection of phospho genes and mRNA genes.
+
+### Preprocessing
+
+- `protwise.paramest.core.process_gene()` extracts:
+  - protein-only row: `protein_data['Psite'].isna() & GeneID == gene`
+  - phosphosite rows: `kinase_data['Gene'] == gene`
+  - RNA rows: `mrna_data['mRNA'] == gene`
+- It converts fixed positional columns to NumPy arrays:
+  - `Pr_data = protein_data.iloc[:, 2:].values`
+  - `P_data = gene_data.iloc[:, 2:].values`
+  - `R_data = rna_data.iloc[:, 1:].values`
+- It computes `num_psites` from phosphosite row count and uses `protwise.steady.initial_condition(num_psites)`.
+
+### Model construction and ODE solving
+
+- `protwise.models.distmod`, `succmod`, and `randmod` define ODE RHS functions and `solve_ode()` wrappers.
+- `distmod.py` and `succmod.py` import `scipy.integrate.odeint` and call it over the configured time grid.
+- `randmod.py` imports `scipy.integrate.odeint` and solves the random/combinatorial local model.
+- The local model state is also structurally mRNA + protein + phospho; the biological structure should remain unchanged.
+
+### Objective construction
+
+- `protwise.paramest.normest.parameter_estimation()` builds `target = np.concatenate([r_data.flatten(), pr_data.flatten(), p_data.flatten()])`.
+- `model_func()` calls `solve_ode()` and returns flattened model predictions, optionally appended with regularization terms.
+- `score_fit()`/config score logic computes scalar metrics over the flattened target/prediction.
+- Regularization is added by appending a regularization vector to the curve-fit target rather than by a clean scalar objective.
+
+### Optimizer setup
+
+- `protwise.paramest.normest.py` imports `scipy.optimize.curve_fit`.
+- `worker_find_lambda()` and `_curve_fit_multistart()` call `curve_fit()` repeatedly.
+- Bootstrapping also calls `curve_fit()` on noisy targets.
+- `protwise.steady.initdist`, `initsucc`, and `initrand` import `scipy.optimize.minimize` and use SLSQP with equality constraints to compute steady-state initial conditions.
+
+### Constraints/bounds
+
+- `config.config.parse_bound_pair()` parses user CLI bounds.
+- `config.config.extract_config()` creates bounds for `A`, `B`, `C`, `D`, `S(i)`, and `D(i)`.
+- `protwise.paramest.normest.parameter_estimation()` builds lower/upper bound vectors. For `randmod`, it logs/transforms bounds and parameters; for other models, it passes physical bounds directly to `curve_fit()`.
+- Initial-condition functions enforce nonnegative variables with SLSQP bounds and equality residual constraints.
+
+### Result extraction, plotting, saving, reporting
+
+- `protwise.paramest.core.process_gene()` computes MSE/MAE against concatenated all-layer targets.
+- It solves the fitted ODE, generates PCA/t-SNE/parallel plots, model-fit plots, knockout simulations, sensitivity analysis, and returns a result dictionary.
+- `common.utils.display.save_result()` writes Excel sheets, site estimates/observations, PCA, t-SNE, sensitivity, knockout, and errors.
+- `protwise.plotting.Plotter.plot_model_fit()` hard-codes mRNA/protein/phospho slices and time grids.
+- `common.utils.display.merge_obs_est()` merges site observed/estimated sheets, not a fully multimodal output table.
+
+## 7. Current Optimizer Dependencies
+
+| File | Function/class | Current role | Why it must change | Proposed future replacement |
+|---|---|---|---|---|
+| `networkmodel/optproblem.py` | `GlobalODE_MOO(ElementwiseProblem)` | Pymoo elementwise multi-objective problem returning 3 objectives. | JAXopt needs a pure scalar objective; Pymoo class/mutation of `System` is incompatible with JAX differentiation/JIT. | Replace with `networkmodel/jax_objective.py` scalar function plus JAXopt solver wrapper. |
+| `networkmodel/runner.py` | Pymoo imports: `UNSGA3`, `StarmapParallelization`, `SBX`, `PM`, `LHS`, `DefaultMultiObjectiveTermination`, `get_reference_directions`, `pymoo_minimize` | Main global optimization path. | Evolutionary multi-objective optimization is being removed. | JAXopt projected solver, e.g. `ProjectedGradient`, `LBFGSB` if box-only, or custom projected loop. |
+| `networkmodel/runner.py` | `run_optuna_solver()` branch | Alternative Optuna multi-objective backend. | Future stack should be JAXopt single-objective; Optuna can at most be a non-core outer hyperparameter search. | Remove from core path or keep as optional outer hyperparameter tuner that calls JAX scalar objective outside differentiable path. |
+| `networkmodel/refine.py` | `UNSGA3`, Pymoo population/operators, `pymoo_minimize` | Refines current Pareto front with tighter bounds. | Pareto-front refinement no longer exists in scalar JAXopt stack. | Replace with restart/multistart JAXopt runs, continuation on bounds, or local polish from previous optimum. |
+| `networkmodel/scan.py` | Optuna outer loop + Pymoo inner UNSGA3 | Hyperparameter scan over lambdas using evolutionary runs. | Inner Pymoo and Pareto results incompatible with new scalar objective; Optuna dashboard language still Pareto-heavy. | Optional scalar hyperparameter search that invokes JAXopt; or static lambda config with deprecation warning. |
+| `networkmodel/optuna_solver.py` | `NativeOptunaObjective`, `run_optuna_solver`, `OptunaResult` | Alternative MOTPE optimizer returning `.X`/`.F`. | Not JAXopt; result object preserves multi-objective semantics. | Remove/deprecate core use; if retained, make it an external scalar hyperparameter-search wrapper, not model optimizer. |
+| `networkmodel/export.py` | functions taking `res.X`, `res.F` | Exports Pareto-front artifacts and parameter distributions. | JAXopt result will not be a Pymoo result and should have a single optimum plus diagnostics. | Export `best_params`, `objective_history`, optional restart table, and scalar diagnostics. |
+| `networkmodel/dashboard_bundle.py` | `save_dashboard_bundle()` | Stores Pymoo/Optuna result object and Pareto arrays. | JAXopt result object/diagnostics differ. | Store serializable scalar optimizer summary, objective trace, gradient norm, projection info, data mode. |
+| `networkmodel/dashboard_app.py` | `_fig_pareto_3d()`, fixed Pareto load | Displays 3D Pareto front. | No Pareto front in scalar optimization. | Replace with objective trace, residual/loss breakdown, restart comparison, and mode-aware prediction plots. |
+| `protwise/paramest/normest.py` | `curve_fit()` in `worker_find_lambda()` | Fits local model for candidate regularization lambdas. | SciPy optimizer and Python/NumPy model callback are not JAX/JAXopt. | JAXopt scalar least-squares/objective with JAX RHS/Diffrax. |
+| `protwise/paramest/normest.py` | `_curve_fit_multistart()` | Multi-start SciPy curve fitting. | Should use JAXopt restarts with projected bounds. | JAXopt multistart wrapper around scalar objective. |
+| `protwise/paramest/normest.py` | bootstrap `curve_fit()` | Fits noisy targets. | Must use same JAXopt objective to preserve consistency. | JAXopt bootstrap loop outside JIT, with JAX arrays per run. |
+| `protwise/steady/initdist.py` | `scipy.optimize.minimize(method='SLSQP')` | Solves equality-constrained steady-state y0. | SciPy constraint dicts are incompatible with JAXopt target. | Analytic y0 where possible; otherwise JAXopt root solve/projection or Diffrax steady-state relaxation. |
+| `protwise/steady/initsucc.py` | `scipy.optimize.minimize(method='SLSQP')` | Same for successive model. | Same issue. | Same replacement. |
+| `protwise/steady/initrand.py` | `scipy.optimize.minimize(method='SLSQP')` | Same for random model. | Same issue. | Same replacement, likely more complex due combinatorial states. |
+| `scripts/compare_estimated_model_simulations_thermal_standard.py` | Pymoo `Problem`, `UNSGA3`, `pymoo_minimize` | Standalone multi-objective thermal comparison. | Script depends on removed Pymoo concepts. | Mark as legacy or port to JAXopt scalar objective if still part of reproducible workflow. |
+
+## 8. Current Multi-Objective Assumptions
+
+| Location | Multi-objective assumption | Future single-objective replacement |
+|---|---|---|
+| `networkmodel/optproblem.py` module docstring | Describes Pymoo compatibility, three objectives, and Pareto-front prior regularization. | Rename to scalar JAX objective documentation. |
+| `GlobalODE_MOO.__init__()` | `n_obj=3`. | Scalar objective function returns one `jax.Array` scalar. |
+| `GlobalODE_MOO._evaluate()` | Returns `out["F"] = [obj_protein, obj_rna, obj_phospho]`. | Return `L_total`; also compute optional non-differentiated loss breakdown for reporting. |
+| `networkmodel/runner.py` | Constructs `UNSGA3` and reference directions using `problem.n_obj`. | Construct a JAXopt solver and projection function; no reference directions. |
+| `networkmodel/runner.py` | Saves `pareto_X.npy`, `pareto_F.npy`, `pareto_F.csv`, `pareto_front.xlsx`. | Save `best_theta.npy`, `best_objective.json`, `objective_history.csv`, optional `restart_results.csv`; keep compatibility aliases only if needed. |
+| `networkmodel/runner.py` | Selects picked solution from a set of Pareto candidates using weighted Fréchet score. | The optimizer returns one best solution; optional post-hoc selection only among restarts/checkpoints. |
+| `networkmodel/export.py::export_pareto_front_to_excel()` | Excel workbook per Pareto solution with `summary`, `traj_protein`, `traj_rna`, `traj_phospho`. | Replace with `export_optimization_result_to_excel()` containing best solution, loss breakdown, parameters, trajectories, restarts/checkpoints. |
+| `networkmodel/export.py::save_pareto_3d()` | 3D plot for `prot_mse`, `rna_mse`, `phospho_mse`. | Objective trace or loss-breakdown bar/line plots. |
+| `networkmodel/export.py::save_parallel_coordinates()` | Parallel coordinates over Pareto solutions/objectives. | Optional parameter/restart comparison plot; no Pareto labels. |
+| `networkmodel/export.py::create_convergence_video()` | Animation of Pareto front evolution. | Objective/history animation or remove with warning. |
+| `networkmodel/export.py::scan_prior_reg()` | Reads `pareto_F.npy` and scans lambda combinations over three objective columns. | Recompute scalar objective breakdown for candidate weights or deprecate. |
+| `networkmodel/export.py::export_param_correlations()` | Correlations across entire Pareto front. | Correlations across restarts/checkpoints/bootstrap samples if available; otherwise skip. |
+| `networkmodel/export.py::export_parameter_distributions()` | Boxplots over Pareto front. | Use bootstrap/restart distribution; not Pareto. |
+| `networkmodel/dashboard_bundle.py` | Stores `pareto_F`, `pareto_X`. | Store `objective_history`, `best_theta`, `loss_breakdown`, `restart_table`. |
+| `networkmodel/dashboard_app.py` | Displays “Pareto front” tab/subheader and 3D scatter. | Display “Optimization objective” and “Loss breakdown”. |
+| `networkmodel/README.md`, `docs/Documentation/global/README.md` | Mention multi-objective loss aggregation, Pymoo, evolutionary/GA, Pareto. | Update to JAXopt scalar objective and Diffrax solver terminology after migration. |
+| `scripts/compare_estimated_model_simulations_thermal_standard.py` | Defines Pymoo multi-objective problem and picks Pareto solution by sum. | Port or mark legacy. |
+
+## 9. Target JAXopt Optimization Design
+
+### Global float64 setup
+
+Add one centralized import/setup module later, for example `networkmodel/jax_config.py` or package-level initialization used by both `networkmodel` and `protwise`:
+
+```python
+import jax
+jax.config.update("jax_enable_x64", True)
+```
+
+This must execute before any JAX arrays/functions are created. Tests should assert `jax.config.read("jax_enable_x64") is True`.
+
+### Pure JAX objective
+
+The future objective path should be:
+
+1. Load and preprocess data with Pandas/NumPy outside JAX.
+2. Convert to immutable numeric JAX arrays: indices, time grids, observation values, weights, masks.
+3. Pack parameters as either a flat `jax.Array` plus slices or a PyTree with named arrays.
+4. Project/reparameterize parameters to biologically valid physical values.
+5. Solve ODE with Diffrax using pure JAX RHS and JAX arrays.
+6. Extract numeric observables with JAX indexing/reductions.
+7. Compute active layer losses with fixed-shape arrays and masks.
+8. Return one scalar `L_total`.
+
+No Pandas, Python dictionaries keyed by strings, mutable `System.update()`, Numba, SciPy, or logging should occur inside the JIT/differentiated objective.
+
+### Parameter container choice
+
+Recommended transitional design:
+
+- Keep a flat vector for compatibility with current `theta0`, `slices`, `xl`, `xu` concepts.
+- Convert `networkmodel.params.init_raw_params()` and `unpack_params()` to JAX-compatible versions that operate on `jax.numpy` arrays.
+- Store slices/static metadata outside JIT, preferably as a small frozen dataclass.
+- For `protwise`, use the same flat-vector convention first, then optionally move to PyTrees after parity tests pass.
+
+Longer-term design:
+
+- Use a parameter PyTree for readability: `{"c_k": ..., "A_i": ..., "B_i": ..., ...}`.
+- Use `jax.flatten_util.ravel_pytree` if JAXopt solver requires a flat vector.
+
+### Projection strategy
+
+- Box bounds: use JAXopt `projection_box` or a custom `jnp.clip` projection.
+- Nonnegative variables: prefer box projection `[0, upper]` in physical space or softplus reparameterization in unconstrained space; avoid both if double-constraining causes poor conditioning.
+- Fixed parameters: remove from optimization vector if possible; otherwise set equal lower/upper bounds and projection enforces constant values.
+- Simplex constraints: use JAXopt simplex projection where true simplex constraints exist. In `networkmodel`/`protwise`, no active alpha/beta simplex optimizer was found outside excluded KinOpt/TFOpt, so only document compatibility for prior values unless future code brings alpha/beta into these modules.
+- Constraint penalties: use only when projection/reparameterization is impractical or non-differentiable shape choices make projection unsuitable.
+
+### Candidate JAXopt solvers
+
+- `jaxopt.ProjectedGradient` for explicit projection over box/simplex constraints.
+- `jaxopt.LBFGSB` if only bound constraints are needed and the flat-vector design is kept.
+- `jaxopt.GradientDescent` or `jaxopt.LBFGS` on unconstrained raw parameters with softplus transforms if projection is deferred.
+- For expensive Diffrax objectives, consider limited iterations, checkpointing, and restarts; measure compile/runtime.
+
+### Diagnostics/result conversion
+
+The future optimizer result should be converted outside JAX to a serializable summary:
+
+- `best_theta`
+- `best_params` physical values
+- `objective_value`
+- `loss_breakdown`: `mrna_loss`, `protein_loss`, `phospho_loss`, regularization
+- `gradient_norm`
+- `iterations`
+- `converged`/status
+- `projection_strategy`
+- `solver_backend="jaxopt"`
+- optional `objective_history`
+- optional restart table
+
+## 10. Constraint and Projection Plan
+
+| Existing/future constraint | Current representation | Recommended future representation | Reason |
+|---|---|---|---|
+| Networkmodel kinetic positivity (`c_k`, `A_i`, `B_i`, `C_i`, `D_i`, `Dp_i`, `E_i`, `tf_scale`) | Softplus transform in `networkmodel.params.unpack_params()` plus raw-space bounds. | Either keep softplus with unconstrained JAXopt or move to physical-space projected box optimization. Prefer one approach consistently. | Avoid negative biological rates while keeping differentiability. |
+| Networkmodel upper/lower bounds | `xl`/`xu` raw-space arrays passed to Pymoo. | JAX arrays `lower`, `upper`; use `jaxopt.LBFGSB` or projection box. | Direct replacement for optimizer bounds. |
+| Networkmodel fixed parameters | Collapsed lower/upper bounds detected by `get_optimized_sets()`. | Remove fixed parameters from optimization vector or use projection to equal bounds. | Reduces optimization dimension and avoids flat gradients. |
+| Protwise kinetic bounds (`A`, `B`, `C`, `D`, `S(i)`, `D(i)`) | `curve_fit(..., bounds=free_bounds)`; random model log-transform. | Shared JAX flat-vector bounds and projection or reparameterization. | Aligns protwise with networkmodel. |
+| Protwise nonnegative initial conditions | SLSQP bounds `(1e-6, None)` in `protwise/steady/init*.py`. | Analytic formulas if possible; otherwise JAX root/least-squares solve with nonnegative projection. | Removes SciPy constraint dictionaries. |
+| Protwise steady-state equality constraints | SLSQP `constraints={'type': 'eq', 'fun': steady_state_equations}`. | Prefer analytic y0, `jaxopt.ScipyRootFinding` is not acceptable for full migration; use JAXopt root/least-squares or Diffrax relaxation to steady state. | Equality constraints are not simple box constraints. |
+| Alpha bounds | In `networkmodel`, alpha values are loaded priors from upstream Excel, not optimized. In legacy docs/common tables they are report values. | Do not add alpha optimization in networkmodel/protwise. If future alpha variables enter these modules, represent bounds with box projection. | Avoid importing excluded KinOpt concerns. |
+| Alpha sum-to-one/simplex | Not active in inspected `networkmodel`/`protwise` optimizer paths. | If introduced later, use JAXopt simplex projection and static group indices. | Projection is cleaner than SciPy constraints. |
+| Beta bounds | Beta values are loaded priors/maps in `networkmodel.io` and `networkmodel.network`; local tables read beta sheets. | Keep as data/prior constants. If optimized later, use box projection. | Not currently an optimized block in scope. |
+| Beta sum-to-one constraint | Not active in inspected `networkmodel`/`protwise` optimizer paths. | If biologically required later, clarify sign domain first; if beta can be negative, simplex is invalid and use affine projection or reparameterization. | Avoid ambiguous simplex with negative bounds. |
+| Mode-specific inactive losses | Current Pymoo has separate objectives even when arrays can be empty. | Numeric layer masks in scalar objective; inactive layers multiply by zero and have zero weights/counts outside JIT. | Compatible with JAX static shapes and multimodal audit. |
+| Regularization | Added per objective in `GlobalODE_MOO`; appended vector in protwise `curve_fit`. | Add scalar regularization terms directly to `L_total`. | Cleaner and differentiable. |
+
+## 11. Multi-Modal Single Objective Plan
+
+The JAX objective should receive a static `DataMode`-derived numeric bundle:
+
+```text
+JaxLossData:
+  p_prot, t_prot, obs_prot, w_prot, mask_prot
+  p_rna,  t_rna,  obs_rna,  w_rna,  mask_rna
+  p_pho,  s_pho,  t_pho,   obs_pho, w_pho, mask_pho
+  layer_weights = {mrna, protein, phospho}
+  active_layer_mask = [fit_protein, fit_mrna, fit_phospho]
+```
+
+Shapes should be fixed before JIT. If variable-length arrays are inconvenient, use arrays sized to actual active observations and compile per mode/run, or padded arrays with boolean masks. Do not use Pandas or Python-side filtering inside the objective.
+
+| Mode | Active outputs | Inactive outputs | Loss terms included/skipped | Expected shapes/checks | Logging/downstream outputs |
+|---|---|---|---|---|---|
+| mRNA only | `R(t)` fold-change | protein, phospho | Include `L_mrna`; skip `L_protein`, `L_phospho`. | `obs_rna`, `p_rna`, `t_rna`, `w_rna` nonempty and finite. | Log `active_losses=[mrna]`; save RNA fitted predictions and scalar objective/loss breakdown. |
+| protein only | total protein fold-change | mRNA, phospho | Include `L_protein`; skip others. | Protein indices/times valid; kinase-input defaults logged if needed. | Save protein predictions only as fitted output. |
+| phospho only | site-specific phospho fold-change | mRNA, protein | Include `L_phospho`; skip others. | `(protein, psite)` mapped to model site indices; nonempty after mechanistic filtering. | Save phospho predictions/S-rates; log missing protein-driver assumptions. |
+| mRNA + protein | `R(t)`, total protein | phospho | Include `L_mrna + L_protein`. | Both observation sets nonempty. | Save RNA/protein fitted predictions and two-layer loss breakdown. |
+| mRNA + phospho | `R(t)`, phosphosites | protein | Include `L_mrna + L_phospho`. | RNA and phospho arrays nonempty; y0 defaults for protein if needed. | Save RNA/phospho predictions; log skipped protein. |
+| protein + phospho | total protein, phosphosites | mRNA | Include `L_protein + L_phospho`. | Protein and phospho arrays nonempty. | Save protein/phospho predictions; log skipped mRNA. |
+| all three | `R(t)`, total protein, phosphosites | none | Include all three plus regularization. | Preserve all-three current behavior except scalar objective. | Save all prediction files and full loss breakdown. |
+
+### Integration with `networkmodel`
+
+- Replace `GlobalODE_MOO` with a scalar objective builder that accepts `JaxSystemStatic`, `JaxLossData`, `bounds/projection`, and `DataMode` metadata.
+- Keep `prepare_fast_loss_data()` concept but return JAX-ready arrays/masks after Pandas preprocessing.
+- `simulate_and_measure()` should have a JAX/Diffrax equivalent for predictions, then convert to Pandas at export.
+
+### Integration with `protwise`
+
+- Replace fixed `np.concatenate([r_data, pr_data, p_data])` with mode-aware numeric target containers.
+- Preserve the same per-gene model state but compute layer losses separately and combine into one scalar.
+- `Plotter.plot_model_fit()` and `save_result()` should consume structured outputs rather than assuming fixed slices.
+
+## 12. Current ODE Solver Dependencies
+
+| File | Function/class | Current role | Solver inputs/outputs | Downstream consumption | Proposed Diffrax replacement |
+|---|---|---|---|---|---|
+| `networkmodel/simulate.py` | `simulate_odeint()` | Main global solver wrapper. | Inputs: `System`, `t_eval`, tolerances, `mxstep`; output NumPy array `Y`. | Loss evaluation, predictions, analysis. | `simulate_diffrax(system_static, params, y0, save_times, solver_config) -> jax.Array`. |
+| `networkmodel/simulate.py` | `simulate_and_measure()` | Solves and returns Pandas prediction tables. | Calls `simulate_odeint()`, extracts observables. | Exports, plots, Frechet selection. | Split into JAX observable extraction plus Pandas conversion wrapper. |
+| `networkmodel/optproblem.py` | `_evaluate()` | Calls `simulate_odeint()` inside Pymoo evaluation. | Returns `Y` for Numba loss. | Pymoo objective. | JAX objective calls Diffrax directly. |
+| `networkmodel/analysis.py` | `simulate_until_steady()` | Post-optimization dynamics check. | Calls `simulate_odeint()` over long time. | Steady-state plots/logs. | Diffrax wrapper with long-horizon `SaveAt`; optionally separate steady-state solver. |
+| `networkmodel/jacspeedup.py` | `rhs_odeint()`, `fd_jacobian_odeint()` | Python wrappers for SciPy `odeint`. | ODEint-compatible `(y, t, *args)`. | Used by `simulate_odeint()`. | Replace with pure JAX RHS `(t, y, args)` for Diffrax. |
+| `networkmodel/network.py` | `System.odeint_args()` | Packs mutable NumPy arrays for ODEint/Numba. | Tuple of arrays and buffers. | `simulate_odeint()`, Numba solver. | Replace with frozen JAX static/numeric args PyTree. |
+| `networkmodel/model_ivp.py` | `make_solve_ivp_fun_*()` | Creates `solve_ivp`-compatible RHS functions. | `(t, y)` functions. | Potential examples/legacy use. | Deprecate or port to Diffrax RHS builders. |
+| `networkmodel/solvers.py` | Custom Numba solver kernels | Avoid SciPy overhead. | Numba arrays, in-place loops. | Used by custom solver path. | Replace with Diffrax; keep only as legacy outside JAX if necessary. |
+| `protwise/models/distmod.py` | `solve_ode()` | Local distributive ODE solve. | Parameters, initial condition, time grid; returns `sol`, flattened fitted vector. | protwise objective, plots, saving. | Diffrax local solver returning structured JAX observables. |
+| `protwise/models/succmod.py` | `solve_ode()` | Local successive ODE solve. | Same. | Same. | Diffrax local solver. |
+| `protwise/models/randmod.py` | `solve_ode()` | Local random/combinatorial ODE solve. | Same with log parameters. | Same. | Diffrax local solver; careful static combinatorial state metadata. |
+| `scripts/thermal_distributive_model_protein.py` | top-level `solve_ivp()` calls | Standalone simulation demo. | `t_span`, `y0`, `t_eval`. | Plots in script. | Port if script remains maintained; otherwise mark legacy. |
+| `scripts/compare_model_simulations_thermal_standard.py` | `solve_ivp()` | Standalone comparison. | `ode_func`, time span/grid. | Script outputs. | Port/legacy decision. |
+| `scripts/compare_estimated_model_simulations_thermal_standard.py` | `solve_ivp()` | Pymoo thermal optimization script. | Local wrapper and temperature parameter. | Script optimization. | Port only if still reproducible workflow. |
+| `scripts/compare_mechanisms.py` | `simulate_odeint()` | Uses networkmodel solver under the hood. | `System`, time grid. | Mechanism comparison. | Use new Diffrax wrapper. |
+
+## 13. Target Diffrax Solver Design
+
+### Centralized solver configuration
+
+Create one central solver config object later, shared by `networkmodel` and `protwise`:
+
+```text
+DiffraxSolverConfig:
+  solver_name: "kvaerno4" | "kvaerno5"
+  rtol: existing relative_tolerance
+  atol: existing absolute_tolerance
+  max_steps: existing max_timesteps / ode_max_steps equivalent
+  nonlinear_solver_maxiter: 10 or 20
+  saveat_times: jax.Array
+  dt0: optional
+```
+
+Suggested solver candidates:
+
+- `diffrax.Kvaerno4` for stiff/semi-stiff production use.
+- `diffrax.Kvaerno5` for potentially higher accuracy at higher cost.
+
+Solver choice should be centralized, not scattered across `networkmodel/simulate.py`, `networkmodel/analysis.py`, `protwise/models/*.py`, and scripts.
+
+### Diffrax solve design
+
+- RHS signature should be pure JAX: `rhs(t, y, args)`.
+- `args` should be a PyTree containing static numeric matrices, parameter arrays, time-grid/driver arrays, model metadata, and mode-independent structures.
+- Use `diffrax.ODETerm(rhs)`.
+- Use `diffrax.SaveAt(ts=save_times)` where `save_times` is the union of active layer time points and any requested diagnostic times.
+- Initial conditions should be precomputed as JAX float64 arrays.
+- Use Diffrax adjoint choices deliberately. Start with a stable default and test gradients; choose `RecursiveCheckpointAdjoint` or another appropriate adjoint based on memory/runtime.
+- For nonlinear/root solving in implicit Kvaerno methods, configure the nonlinear solver through Diffrax/Optimistix APIs as supported by installed Diffrax versions. Plan for `max_steps`/nonlinear max iterations such as 10 or 20, and log the selected values.
+
+### Error handling
+
+- Solver failure should produce a deterministic high scalar penalty outside JIT or via JAX-safe failure handling if possible.
+- Avoid Python exceptions inside JIT objective when possible. Validate inputs before optimization.
+- Log solver settings and failure rates outside the JIT loop.
+
+### Conversion to downstream formats
+
+- Diffrax solution `sol.ys` should remain JAX arrays through observable/loss computation.
+- For exports/plots, convert with `np.asarray()` at the boundary and build Pandas data frames using existing column names where possible.
+- Preserve current prediction file names in all-three/all-active compatibility mode, but store backend metadata (`solver_backend=diffrax`, `solver_name=Kvaerno4/5`).
+
+## 14. JAX Compatibility Risks
+
+| Risk | Affected files/functions | Why it matters | Plan |
+|---|---|---|---|
+| NumPy inside objective | `networkmodel/params.py`, `networkmodel/lossfn.py`, `networkmodel/models.py`, `protwise/models/*.py`, `protwise/paramest/normest.py` | NumPy breaks JAX tracing/gradients. | Port differentiable functions to `jax.numpy`; keep NumPy only outside core. |
+| Pandas inside objective | `networkmodel/io.py`, `networkmodel/simulate_and_measure()`, `protwise/core.py` | Pandas is non-JAX and dynamic. | Precompute numeric arrays before objective; convert to Pandas only after optimization. |
+| SciPy calls inside objective | `networkmodel/simulate.py`, `protwise/models/*.py`, `protwise/steady/init*.py` | SciPy solvers/optimizers are not differentiable JAX functions. | Replace with Diffrax/JAXopt. |
+| Numba in differentiated path | `networkmodel/lossfn.py`, `networkmodel/models.py`, `networkmodel/jacspeedup.py`, `networkmodel/solvers.py`, `networkmodel/utils.py`, local models | Numba is not JAX-differentiable. | Replace JAX objective path; optionally leave Numba only as legacy non-JAX path during transition. |
+| Python-side mutation | `System.update(**params)` mutates arrays; `GlobalODE_MOO._evaluate()` mutates `self.sys`. | JAX functions must be pure. | Use immutable parameter PyTrees and pure RHS functions. |
+| Dynamic shapes | Variable number of observations/sites/states by mode/protein. | JIT recompilation or tracing errors. | Precompute static arrays per run; pad/mask if needed. |
+| Object arrays/strings | `Index.proteins`, `idx.sites`, Pandas identifiers. | JAX needs numeric arrays. | Map identifiers to integer indices before JAX. |
+| NaN handling | Missing values, zero baselines, dropped rows. | NaNs poison gradients. | Validate/preclean data; use eps floors in JAX. |
+| float32/float64 mismatch | JAX defaults to float32 unless enabled. | Numerical differences and stiff solver instability. | Enable x64 globally and test dtypes. |
+| Non-JAX interpolation | `KinaseInput.eval()` uses Python/NumPy search and mutation. | Not JAX-differentiable. | Use JAX-compatible interpolation/step lookup with static grids. |
+| Non-JAX normalization | `normalize_fc_to_t0()`, fold-change extraction with Pandas/NumPy. | Should not happen inside objective. | Do data normalization outside JAX or implement JAX observable normalization for predictions only. |
+| Logging inside JIT | Current runner/export logs freely. | Side effects are not allowed in JIT/grad. | Log before/after solver calls, not inside objective. |
+| Current Optuna objective direct indexing | `networkmodel/optuna_solver.py` uses raw state indices not fold-change observable aggregation. | Incorrect or inconsistent when porting. | Do not reuse; build one canonical JAX objective. |
+
+## 15. Downstream Output Impact
+
+### Result tables
+
+- Current `pareto_F.csv` and `pareto_X.npy` should be replaced by scalar optimization outputs such as `objective_history.csv`, `best_theta.npy`, `best_params.json`, `loss_breakdown.json`, and optional `restart_results.csv`.
+- To preserve compatibility, the implementation may write deprecated aliases with clear metadata, but should avoid pretending there is a Pareto front.
+- `picked_objectives.json` should become `best_objective.json` or include `total_objective` and per-layer loss breakdown. Existing filename can be retained for backward compatibility with a schema-version field.
+
+### Plots
+
+- Replace Pareto plots with objective trace, gradient norm trace, loss breakdown bar plots, and restart comparison plots.
+- Goodness-of-fit plots should remain but must be mode-aware and should operate on post-optimization Pandas data frames.
+- Parameter distribution/correlation plots should use bootstrap/restarts/checkpoints, not Pareto samples.
+
+### Reports/dashboard
+
+- Dashboard should remove “Pareto front” language and show scalar objective convergence and mode-aware layer outputs.
+- `dashboard_bundle.pkl` should not store unserializable JAXopt internals. Store NumPy arrays/scalars and metadata only.
+
+### Scripts
+
+- Scripts that consume `pareto_F.npy`, `pareto_F.csv`, or Pymoo result `.F`/`.X` need compatibility wrappers or updates.
+- Scripts using `simulate_odeint()` should call a new solver-agnostic `simulate()` wrapper that internally uses Diffrax after migration.
+
+### Logs
+
+- Logs should state backend `JAXopt + Diffrax`, selected solver, selected data mode, scalar objective value, loss breakdown, and any deprecated config mappings.
+
+## 16. Dashboard, Scripts, and Notebook Impact
+
+### Dashboard
+
+| File | Current old-stack reference | Future update |
+|---|---|---|
+| `networkmodel/dashboard_app.py` | Docstring mentions Pareto frontiers. | Replace with scalar optimization/convergence terminology. |
+| `networkmodel/dashboard_app.py::_load_outputs()` | Reads `pareto_F.csv`; otherwise creates DataFrame from `bundle["res"].F` with three fixed columns. | Load `objective_history.csv`, `loss_breakdown.json`, and `restart_results.csv`; no `.F` dependency. |
+| `networkmodel/dashboard_app.py::_fig_pareto_3d()` | Plots `prot_mse`, `rna_mse`, `phospho_mse`. | Replace with objective trace/loss breakdown. |
+| `networkmodel/dashboard_app.py::main()` | Gallery includes `pareto_front_3d.png`, `pareto_pcp.png`; Overview tab says “Pareto front”. | Replace gallery and labels. |
+| `networkmodel/dashboard_app.py` | Time-series sections assume all three observed data frames exist. | Use data-mode metadata to hide skipped layers. |
+
+### Scripts
+
+| File | Reference | Plan |
+|---|---|---|
+| `scripts/compare_estimated_model_simulations_thermal_standard.py` | Imports Pymoo and `solve_ivp`, defines Pymoo problem and UNSGA3 run. | Port only if still maintained; otherwise mark legacy and remove from reproducible migration path. |
+| `scripts/compare_model_simulations_thermal_standard.py` | Uses `solve_ivp`. | Replace with Diffrax or script-level compatibility wrapper. |
+| `scripts/thermal_distributive_model_protein.py` | Uses `solve_ivp`. | Replace with Diffrax demo or mark legacy. |
+| `scripts/compare_mechanisms.py` | Imports `simulate_odeint`, comments that it uses odeint. | Update to new `simulate_diffrax`/solver-agnostic wrapper and rename comments. |
+| Other `scripts/*.py` | Some consume exported results rather than solving/optimizing. | Update only if they expect Pareto columns/files. |
+
+### Notebooks
+
+No `.ipynb` files were found outside excluded paths during this audit. If notebooks are later added or generated, search them for `pymoo`, `Pareto`, `odeint`, `solve_ivp`, `curve_fit`, `Optuna`, `UNSGA`, `scipy.optimize`, and fixed output filenames before migration completion.
+
+## 17. Config Backward Compatibility Plan
+
+### Current config usage
+
+- `[networkmodel].optimizer` accepts values such as `"pymoo"` or `"optuna"`.
+- `[networkmodel].n_gen`, `pop`, `refine`, `num_refinements`, `study_name`, `sampler`, `pruner`, `n_trials`, and `hyperparam_scan` are optimizer-related.
+- `[networkmodel].loss`, lambdas, scaling, weighting, and regularization values affect objective/loss.
+- `[networkmodel.solver]` contains `absolute_tolerance`, `relative_tolerance`, `max_timesteps`, and `use_custom_solver`.
+- `[ode]` and `[ode.bounds]` configure the legacy/protwise model and bounds.
+- `config/config.py` also parses CLI bounds for the local workflow.
+
+### Backward-compatible mapping
+
+| Existing key/option | Future handling |
+|---|---|
+| `optimizer="pymoo"` | Accept but log deprecation: internally map to JAXopt default. |
+| `optimizer="optuna"` | Accept but log that core optimizer is JAXopt; optional outer hyperparameter search only if explicitly retained. |
+| `n_gen` | Map to JAXopt max iterations or accepted but logged as deprecated in favor of internal `maxiter`. No schema change. |
+| `pop` | For scalar JAXopt, map to number of restarts only if multistart is enabled; otherwise ignore with warning. |
+| `refine`, `num_refinements` | Map to local polish/restart refinement if implemented; otherwise accepted but unused with warning. |
+| `study_name`, `sampler`, `pruner`, `n_trials` | Keep accepted; only used if optional outer hyperparameter search remains. Otherwise warn. |
+| `loss` | Map to existing robust loss-mode choices inside JAX loss function where feasible. |
+| `lambda_protein`, `lambda_rna`, `lambda_phospho`, `lambda_prior` | Continue to weight scalar loss components. |
+| `weighting_method_*` | Continue to generate layer weights outside JAX and pass numeric arrays/masks into objective. |
+| `absolute_tolerance`, `relative_tolerance`, `max_timesteps` | Map directly to Diffrax `rtol`, `atol`, and `max_steps`. |
+| `use_custom_solver` | Accept but log deprecation; Diffrax is the internal solver backend. |
+| `[ode.bounds]` and CLI bound args | Preserve for protwise JAXopt projection/bounds. |
+
+Default future backend should be logged as `optimizer_backend=jaxopt`, `solver_backend=diffrax`, `jax_enable_x64=True`.
+
+## 18. Logging and Console Plan
+
+Future logs should include:
+
+- `[Backend] JAX float64 enabled: True`
+- `[Optimizer] Backend: JAXopt; solver: ProjectedGradient/LBFGSB; maxiter=...`
+- `[Optimizer] Deprecated config optimizer='pymoo' accepted and mapped to JAXopt` when applicable.
+- `[Solver] Backend: Diffrax; solver=Kvaerno4/Kvaerno5; rtol=...; atol=...; max_steps=...; nonlinear_maxiter=10/20`
+- `[Mode] Detected data mode: ...; active layers: ...; skipped layers: ...`
+- `[Loss] Active terms: ...; weights: ...; regularization: ...`
+- `[Params] Blocks: c_k=..., A_i=..., B_i=..., ...; optimized_dim=...; fixed_dim=...`
+- `[Projection] Strategy: box/simplex/softplus/fixed-mask; bounds validated`
+- `[Optimize] Iterations=...; objective=...; grad_norm=...; converged=...`
+- `[Output] Saved scalar optimization diagnostics: ...`
+- Warnings for stale Pymoo/Optuna/SciPy options and unavailable optional data layers.
+
+Do not log inside JIT-compiled objective functions.
+
+## 19. Files That Must Change Later
+
+| File | Current role | Required future change | Reason | Risk level | Notes |
+|---|---|---|---|---|---|
+| `networkmodel/runner.py` | Global orchestration with Pymoo/Optuna and Pareto outputs. | Replace optimizer setup/result handling with JAXopt scalar flow; route solver to Diffrax; mode-aware outputs. | Central old-stack dependency. | Very high | Preserve CLI/config surface. |
+| `networkmodel/optproblem.py` | Pymoo `GlobalODE_MOO`. | Replace/deprecate with scalar JAX objective module. | Pymoo/multi-objective incompatible. | Very high | Could keep temporarily as legacy behind flag. |
+| `networkmodel/simulate.py` | SciPy `odeint` and custom solver wrapper. | Replace with Diffrax centralized solver wrapper. | Required solver migration. | Very high | Preserve `simulate_and_measure` compatibility wrapper. |
+| `networkmodel/models.py` | Numba RHS kernels. | Add/replace with pure JAX RHS functions. | Diffrax/JAXopt need JAX RHS. | Very high | Keep model equations unchanged. |
+| `networkmodel/lossfn.py` | Numba loss kernels. | Port to pure JAX scalar/masked loss. | Numba cannot be differentiated by JAX. | High | Use previous multimodal layer masks. |
+| `networkmodel/cache.py` | Numeric loss pre-indexing. | Emit JAX-ready arrays/masks and no fake counts. | Objective data boundary. | High | Good place for data validation. |
+| `networkmodel/params.py` | NumPy packing/unpacking and softplus. | JAX-compatible packing/projection; fixed parameter handling. | Needed for JAXopt. | High | Preserve slice semantics initially. |
+| `networkmodel/network.py` | Mutable `System`, Numba buffers, `odeint_args`. | Split into static metadata and immutable JAX numeric containers. | Mutation/Numba incompatible. | Very high | Keep `Index` as preprocessing metadata if outside JAX. |
+| `networkmodel/jacspeedup.py` | Numba RHS/Jacobian for odeint. | Remove from differentiable path; deprecate/replace. | Not JAX/Diffrax. | High | Could remain temporarily legacy. |
+| `networkmodel/solvers.py` | Custom Numba solver. | Replace with Diffrax or isolate as legacy. | Not JAX/Diffrax. | High | Current comments mention SciPy solvers. |
+| `networkmodel/export.py` | Pareto/multi-objective exports. | Convert to scalar objective outputs, loss breakdowns, restart/checkpoint exports. | Downstream assumptions. | High | Keep old filenames only as compatibility aliases if needed. |
+| `networkmodel/dashboard_bundle.py` | Stores Pymoo-like result data. | Store JAXopt diagnostics and mode metadata. | Dashboard compatibility. | Medium | Avoid serializing JAX internals. |
+| `networkmodel/dashboard_app.py` | Pareto dashboard. | Replace Pareto UI with scalar objective UI. | User-facing dashboard would break. | Medium | Not edited until core complete. |
+| `networkmodel/refine.py` | Pymoo refinement. | Replace with JAXopt restarts/local polish or deprecate. | Pymoo dependency. | Medium/high | May be optional. |
+| `networkmodel/scan.py` | Optuna+Pymoo scan. | Replace or deprecate for scalar JAXopt. | Pymoo/Optuna core dependency. | Medium/high | Optional outer scan only. |
+| `networkmodel/optuna_solver.py` | Optuna alternative solver. | Remove/deprecate or rewrite as optional scalar outer tuner. | Not JAXopt core. | High | Current loss indexing suspect. |
+| `networkmodel/analysis.py` | Uses `simulate_odeint()`. | Call Diffrax wrapper. | Solver migration. | Medium | Post-optimization only. |
+| `protwise/paramest/normest.py` | SciPy `curve_fit` objective/fitting. | Port to JAXopt scalar objective and multistart/bootstrap wrappers. | Main protwise optimizer. | Very high | Must be mode-aware too. |
+| `protwise/models/distmod.py` | Local ODE `odeint`. | Port to Diffrax/JAX RHS. | Solver migration. | High | Preserve output semantics via wrapper. |
+| `protwise/models/succmod.py` | Local ODE `odeint`. | Port to Diffrax/JAX RHS. | Solver migration. | High | Same. |
+| `protwise/models/randmod.py` | Local random model `odeint`. | Port to Diffrax/JAX RHS. | Solver migration. | High | Static combinatorial metadata needed. |
+| `protwise/steady/initdist.py` | SciPy SLSQP y0. | Replace with analytic/JAX root/projection. | SciPy optimize dependency. | Medium/high | Similar for all init files. |
+| `protwise/steady/initsucc.py` | SciPy SLSQP y0. | Same. | Same. | Medium/high |  |
+| `protwise/steady/initrand.py` | SciPy SLSQP y0. | Same. | Same. | High | More states. |
+| `protwise/paramest/core.py` | Calls estimator/solver and builds metrics. | Use JAXopt result and structured mode-aware outputs. | Integrates protwise migration. | High | Keep reporting interface stable. |
+| `protwise/plotting/plotting.py` | Fixed output slicing. | Mode-aware plotting from structured outputs. | Multimodal/JAX output changes. | Medium | Outside JAX. |
+
+## 20. Files That May Need Minor Adaptation
+
+| File | Current role | Possible future change | Trigger condition | Risk level |
+|---|---|---|---|---|
+| `networkmodel/io.py` | Data loading/preprocessing. | Produce JAX-ready numeric data bundle after Pandas loading. | When objective port starts. | Medium |
+| `networkmodel/utils.py` | Config dataclass, bounds, helpers. | Remove/replace Numba helpers in core path; add JAX-safe bounds utilities. | When parameter projection is implemented. | Medium |
+| `networkmodel/config.py` | Exposes config constants. | Map old optimizer/solver constants to internal JAXopt/Diffrax defaults. | Backend migration. | Low/medium |
+| `config_loader.py` | Loads config schema. | Possibly add internal default mapping only, no schema changes. | If new internal defaults need centralization. | Low |
+| `config/config.py` | Local CLI bounds/scoring. | Keep bounds but map local optimizer behavior to JAXopt. | protwise migration. | Low/medium |
+| `config/constants.py` | Local ODE constants. | Keep current keys; ensure JAX dtype/time grids are converted later. | protwise migration. | Low |
+| `common/utils/display.py` | Local saving/reporting. | Mode-aware sheet names and scalar objective fields. | If protwise output schema changes. | Medium |
+| `common/utils/tables.py` | Alpha/beta report tables. | Likely unchanged unless output files change. | If prior-result table locations change. | Low |
+| `common/frechet/distance.py` | Numba Frechet metric. | Keep outside objective or replace with JAX metric only if used in objective. | If Frechet becomes scalar objective term. | Medium |
+| `processing/*.py` | Preprocessing/mapping. | Likely no change. | Only if output schema for upstream files changes. | Low |
+| `run_dashboard.py` | Dashboard launcher. | Probably unchanged; app content changes. | If CLI args change, which should be avoided. | Low |
+| `scripts/*.py` | Standalone analysis. | Update old solver/optimizer references if maintained. | After core migration. | Medium |
+| `docs/**/*.md`, `README.md`, `PYPI_README.md` | Documentation. | Update old optimizer/solver terminology after implementation. | After code migration is tested. | Low |
+
+## 21. Files That Should Not Be Modified Unless Necessary
+
+| File | Reason to preserve | Risk if changed |
+|---|---|---|
+| `config.toml` | User-facing schema must remain unchanged. | Breaking user configs and violating requirement. |
+| `config/cli.py` | CLI should remain stable; backend changes should be internal. | User-facing API break. |
+| `config/logconf.py` | Logging infrastructure is sufficient. | Duplicate handler/test regressions. |
+| `tests/test_config.py` | Existing logging tests unrelated. | Unnecessary churn. |
+| `networkmodel/buildmat.py` | Topology matrix construction can remain preprocessing/outside JAX initially. | Risk of changing biological topology. |
+| `networkmodel/io.py` parsing semantics | Data interface should remain stable; only add numeric bundle outputs carefully. | Input regressions. |
+| `docs/assets/*` | Static assets unrelated to solver/optimizer. | No value. |
+| Excluded `kinopt`/`tfopt` paths | Out of scope by requirement. | Scope violation. |
+
+## 22. Proposed Implementation Phases for a Later Agent
+
+### Phase 1: Add global JAX float64 setup
+
+Files likely involved: new `networkmodel/jax_config.py`, possibly shared utility imported by `networkmodel` and `protwise` JAX modules.
+
+Checks:
+
+- Assert `jax_enable_x64` is true.
+- No legacy code behavior changes yet.
+
+### Phase 2: Isolate current objective functions
+
+Files: `networkmodel/optproblem.py`, `networkmodel/lossfn.py`, `protwise/paramest/normest.py`.
+
+Checks:
+
+- Current scalar/layer loss calculations are documented and covered by baseline tests.
+- Identify all inputs needed by objective independent of runner state.
+
+### Phase 3: Create JAX-compatible parameter containers
+
+Files: `networkmodel/params.py`, `protwise/paramest/normest.py`, possibly new shared parameter module.
+
+Checks:
+
+- Pack/unpack parity against NumPy current implementation.
+- Bounds/projection shapes match current parameter blocks.
+
+### Phase 4: Port networkmodel objective to pure JAX
+
+Files: new JAX objective module, `networkmodel/cache.py`, `networkmodel/models.py` or new JAX RHS module.
+
+Checks:
+
+- Objective returns scalar JAX array.
+- Loss breakdown matches old code on small fixed examples without optimization.
+
+### Phase 5: Port protwise objective to pure JAX
+
+Files: `protwise/paramest/normest.py`, local model JAX RHS modules.
+
+Checks:
+
+- One-gene objective returns scalar.
+- Existing all-three target parity on small fixture.
+
+### Phase 6: Add projection/bounds/constraint handling
+
+Files: `networkmodel/params.py`, protwise parameter code, new projection utilities.
+
+Checks:
+
+- Box projection, nonnegative projection, fixed parameters, and optional simplex projection tests.
+
+### Phase 7: Replace optimizer calls with JAXopt
+
+Files: `networkmodel/runner.py`, `protwise/paramest/normest.py`, deprecate `optproblem.py` path.
+
+Checks:
+
+- JAXopt run produces best params and scalar diagnostics.
+- No Pymoo required in core networkmodel/protwise path.
+
+### Phase 8: Replace ODE solvers with Diffrax
+
+Files: `networkmodel/simulate.py`, `networkmodel/models.py` or JAX RHS module, `protwise/models/*.py`.
+
+Checks:
+
+- `diffrax.Kvaerno4` and `diffrax.Kvaerno5` execute on fixtures.
+- Solver output shape matches old solvers.
+
+### Phase 9: Integrate multi-modal single-objective loss handling
+
+Files: `networkmodel/cache.py`, JAX objective modules, `protwise/paramest/core.py`, `protwise/paramest/normest.py`.
+
+Checks:
+
+- All seven modes include/skip correct terms.
+- No fake zeros/NaNs for missing layers.
+
+### Phase 10: Update result extraction
+
+Files: `networkmodel/runner.py`, `networkmodel/export.py`, `protwise/paramest/core.py`, `common/utils/display.py`.
+
+Checks:
+
+- Best params/loss breakdown/predictions are exported.
+- Existing all-three filenames preserved where feasible.
+
+### Phase 11: Update plotting/saving/reporting
+
+Files: `networkmodel/export.py`, `protwise/plotting/plotting.py`, `common/utils/display.py`.
+
+Checks:
+
+- No Pareto plots in scalar mode.
+- Mode-aware plots generate.
+
+### Phase 12: Update dashboard/scripts/notebooks references
+
+Files: `networkmodel/dashboard_app.py`, `networkmodel/dashboard_bundle.py`, scripts, docs.
+
+Checks:
+
+- Dashboard loads scalar diagnostics.
+- Maintained scripts no longer import Pymoo/SciPy solvers for core path.
+
+### Phase 13: Add logging and warnings
+
+Files: `runner.py`, `protwise/runner/main.py`, config mapping utilities.
+
+Checks:
+
+- Deprecated config warnings visible.
+- Backend/mode/solver/objective logs present.
+
+### Phase 14: Add tests
+
+Files: `tests/` new JAX/Diffrax/mode tests.
+
+Checks:
+
+- See Section 23.
+
+### Phase 15: Remove or deprecate SciPy/pymoo references
+
+Files: old optimizer/solver modules, docs, scripts.
+
+Checks:
+
+- Search confirms no core `networkmodel`/`protwise` optimization path imports `pymoo`, `scipy.optimize`, `odeint`, or `solve_ivp`.
+- Excluded KinOpt/TFOpt untouched.
+
+## 23. Test Plan for Later Implementation
+
+- Test JAX float64 is enabled before computation.
+- Test `networkmodel` JAX objective returns a rank-0 scalar JAX array.
+- Test `protwise` JAX objective returns a rank-0 scalar JAX array.
+- Test all seven multimodal modes include exactly the intended loss terms.
+- Test alpha bound/simplex projection utilities if alpha variables are introduced in scope; otherwise test alpha priors remain constants.
+- Test beta bounds/simplex handling if beta variables are introduced; otherwise test beta priors remain constants.
+- Test nonnegative kinetic parameter projection.
+- Test lower/upper bound projection.
+- Test fixed parameters remain fixed after projection/optimization step.
+- Test Diffrax `Kvaerno4` execution for global and local models.
+- Test Diffrax `Kvaerno5` configuration/execution for at least one small fixture.
+- Test solver output shape and dtype are float64.
+- Test optimizer convergence summary contains objective value, iterations, gradient norm/status.
+- Test downstream result tables contain scalar objective and per-layer loss breakdown.
+- Test plotting compatibility for all-three and at least one single-layer mode.
+- Test saving compatibility: prediction files and JSON summaries exist as expected.
+- Test config backward compatibility for old `optimizer="pymoo"`, `optimizer="optuna"`, `use_custom_solver`, `n_gen`, and `pop`.
+- Test no KinOpt/TFOpt paths changed by migration.
+- Test no `pymoo` import in core PhosKinTime `networkmodel`/`protwise` path.
+- Test no `scipy.optimize` import in PhosKinTime `networkmodel`/`protwise` optimization path.
+- Test no `odeint`/`solve_ivp` use in PhosKinTime `networkmodel`/`protwise` solver path.
+- Test dashboard bundle loads without `.F`/`.X` result fields.
+- Test scripts either run through compatibility wrappers or are explicitly marked legacy.
+
+## 24. Risks and Failure Modes
+
+- Existing phospho workflow could break if observable aggregation changes from old Numba loss semantics.
+- Objective may become non-differentiable if Python/NumPy/Pandas/Numba remains in the path.
+- Projection may conflict with existing softplus transforms if both are applied at once.
+- Beta simplex constraints are ambiguous if beta values can be negative; do not assume simplex unless sign/domain is explicit.
+- Diffrax Kvaerno solvers may expose stiffness or convergence issues hidden by LSODA/odeint.
+- Numerical results may change due to solver, tolerances, adjoints, or float64 JAX behavior.
+- Runtime may initially be slower due to JAX compilation or Diffrax adjoint overhead.
+- Dashboard may break if it expects Pareto files/columns.
+- Documentation and notebooks may become stale if old terms remain.
+- Config options like `pop`, `n_gen`, `optimizer`, and `use_custom_solver` may become misleading without deprecation logs.
+- Downstream files/scripts may expect `pareto_F.csv`, `pareto_X.npy`, and `pareto_front.xlsx`.
+- Hidden SciPy dependency may remain in standalone scripts or comments.
+- Shape mismatches may appear in multimodal losses if missing layers are not padded/masked consistently.
+- JAX dynamic-shape recompilation can be expensive if every gene/mode compiles separately.
+- Python-side mutation in `System` may accidentally remain and invalidate gradients.
+- Replacing protwise `curve_fit` may alter local model fit behavior and confidence/bootstrap outputs.
+
+## 25. Final Recommendation
+
+Migrate in small, testable layers. First isolate the current `networkmodel` and `protwise` objective/solver paths and create JAX-compatible parameter/data containers while leaving the user-facing config unchanged. Convert the objectives to pure JAX scalar functions before replacing the ODE solver. Then introduce Diffrax with centralized `diffrax.Kvaerno4`/`diffrax.Kvaerno5` configuration and float64 enabled. Replace Pymoo/Optuna/SciPy optimizer calls with JAXopt projected or bound-constrained solvers only after objective and solver parity tests pass.
+
+Handle `networkmodel` and `protwise` separately but consistently: both should use a scalar objective, shared mode-aware loss principles, shared projection/bounds utilities where practical, and the same JAX/Diffrax dtype/config conventions. Preserve downstream output contracts where possible, but replace multi-objective/Pareto language everywhere with scalar objective, loss breakdown, convergence, and restart/checkpoint terminology. Test all seven multimodal modes before removing old code paths, and do not touch KinOpt/TFOpt.

--- a/docs/phoskintime_multimodal_input_audit.md
+++ b/docs/phoskintime_multimodal_input_audit.md
@@ -1,0 +1,967 @@
+# PhosKinTime Multi-Modal Input Audit
+
+## 1. Purpose
+
+This is an audit-only planning document for a future implementation of concurrent mRNA, protein, and phosphoprotein/phosphosite data support in PhosKinTime. It documents how PhosKinTime currently loads data, builds model state, constructs losses, optimizes, plots, saves, and logs results, then proposes a safe internal design for mode-aware fitting without changing the user-facing configuration schema.
+
+The intended future behavior is that the same core ODE model continues to expose transcript, protein, and phosphorylation observables, while the objective function includes only the observable layers that are actually available in the input data. The implementation should support all seven non-empty data-layer combinations:
+
+1. mRNA only
+2. protein only
+3. phospho only
+4. mRNA + protein
+5. mRNA + phospho
+6. protein + phospho
+7. mRNA + protein + phospho
+
+The audit focuses on PhosKinTime-relevant source, CLI, configuration, input, model, optimization, plotting, saving, logging, tests, examples, and documentation outside KinOpt and TFOpt.
+
+## 2. Non-goals
+
+- No code changes are proposed or implemented in this audit.
+- No Python files, tests, or configuration files should be edited for this audit.
+- No configuration schema changes should be required for the future implementation.
+- KinOpt and TFOpt are intentionally ignored. This document does not audit, modify, or propose changes for `kinopt`, `tfopt`, or files/modules/configs that specifically belong to KinOpt or TFOpt.
+- No unrelated refactor is recommended as a prerequisite.
+- No separate unrelated models should be created for different input data types.
+- No redesign of the biological model is recommended beyond making observable extraction, loss construction, optimization bookkeeping, outputs, plotting, and logging mode-aware.
+
+## 3. Current Repository Structure Relevant to PhosKinTime
+
+The PhosKinTime-relevant repository structure outside KinOpt and TFOpt appears to have two ODE-oriented workflows:
+
+### Global network model workflow
+
+| File/folder | Apparent role |
+|---|---|
+| `networkmodel/` | Integrated network-scale ODE pipeline. This is the most relevant target for concurrent mRNA/protein/phospho inputs because it already has RNA, protein, and phospho observables and a three-objective optimizer. |
+| `networkmodel/runner.py` | Main orchestration entry point for the global model: parses CLI args, logs configuration, loads data, builds the model index, builds matrices, constructs loss data, runs Pymoo/Optuna, selects a solution, saves outputs, plots, and logs final summaries. |
+| `networkmodel/io.py` | Loads kinase and TF networks, optional prior Excel outputs, mass-spec data, RNA data, and reshapes/scales observations into tidy `df_prot`, `df_pho`, and `df_rna` data frames. Currently reads both protein and phospho from `args.ms` and reads RNA from `args.rna`. |
+| `networkmodel/network.py` | Defines `Index`, `KinaseInput`, and `System`. These map biology to state-vector indices, interpolate protein/kinase data, attach optional data-driven initial conditions, and expose the ODE RHS. |
+| `networkmodel/models.py` | Low-level model-specific RHS kernels for distributive, sequential, combinatorial, and saturating dynamics. Relevant because it determines structural state layout but should not need mode-specific branching. |
+| `networkmodel/simulate.py` | Solves the ODE and extracts predicted RNA, protein, and phospho fold-change data frames via `simulate_and_measure`. |
+| `networkmodel/lossfn.py` | Numba loss kernels for non-combinatorial and combinatorial models. It computes separate protein, RNA, and phospho losses from state trajectories and indexed observation arrays. |
+| `networkmodel/cache.py` | Converts tidy observations into integer arrays for fast loss calculation. Currently processes all three layers and returns count/weight arrays for each. |
+| `networkmodel/optproblem.py` | Defines `GlobalODE_MOO`, a Pymoo `ElementwiseProblem` with fixed `n_obj=3` for protein, RNA, and phospho objectives. Also contains time-weighting utilities. |
+| `networkmodel/optuna_solver.py` | Alternative Optuna solver path. It has its own loss-index augmentation and currently expects protein, RNA, and phospho target/index keys in a different shape than `prepare_fast_loss_data`. |
+| `networkmodel/params.py` | Initializes and unpacks parameter vectors (`c_k`, `A_i`, `B_i`, `C_i`, `D_i`, `Dp_i`, `E_i`, `tf_scale`). These should stay structurally consistent across modes. |
+| `networkmodel/buildmat.py` | Builds kinase-substrate and TF regulatory matrices from cleaned network tables. Relevant to model setup, not to data-layer mode selection except when available observations affect the modeled universe. |
+| `networkmodel/export.py` | Exports Pareto fronts, predictions, model parameters, residuals, plots, S-rate reports, convergence artifacts, and per-gene time-series plots. Many functions assume all three modalities exist. |
+| `networkmodel/dashboard_bundle.py` | Saves a pickle bundle containing args, Pareto data, bounds, defaults, data frames, scores, and selected index for dashboard use. Should include mode metadata later. |
+| `networkmodel/dashboard_app.py` and `run_dashboard.py` | Interactive dashboard entry points for saved global-model outputs. Relevant for output schema compatibility. |
+| `networkmodel/refine.py`, `networkmodel/scan.py`, `networkmodel/sensitivity.py`, `networkmodel/analysis.py`, `networkmodel/steadystate.py` | Downstream optimization refinement, hyperparameter scan, sensitivity, steady-state simulation, and data-derived initial-condition support. They need only targeted adjustments if they assume three objectives/layers. |
+| `networkmodel/config.py` | Imports parsed config values from `config_loader.load_config_toml()` and exposes global constants used by the global model. |
+| `networkmodel/README.md`, `networkmodel/INTERPRETATION.md` | Global-model documentation and interpretation guidance. Should be updated only after implementation. |
+
+### Legacy/local PhosKinTime ODE workflow
+
+| File/folder | Apparent role |
+|---|---|
+| `protwise/` | Legacy/local per-protein ODE workflow and analysis utilities. It fits one gene/protein at a time and already models mRNA, protein, and phosphosite states, but currently requires common genes across mRNA and phosphorylation inputs. |
+| `protwise/runner/main.py` | Legacy/local runner. Loads protein CSV, phosphosite Excel, mRNA Excel; validates fixed columns; restricts processing to the intersection of phospho genes and mRNA genes; calls `process_gene_wrapper`; then saves, plots, and reports. |
+| `protwise/paramest/core.py` | Per-gene orchestration: extracts protein-only rows, phosphosite rows, and mRNA rows; builds arrays; calls parameter estimation; computes metrics; solves the ODE; generates plots, knockout simulations, sensitivity, and returns result dictionaries. |
+| `protwise/paramest/normest.py` | Builds a single flattened target vector as `[mRNA, protein, phospho]`, fits by `scipy.optimize.curve_fit`, and scores the fit. Currently assumes all three layers are present. |
+| `protwise/paramest/toggle.py` | Selects/dispatches the parameter-estimation implementation used by the local workflow. |
+| `protwise/models/distmod.py`, `protwise/models/succmod.py`, `protwise/models/randmod.py` | Local ODE model implementations. The state layout is `R`, `P`, and one or more phosphosite states. Their output flattening is currently fixed to mRNA + protein + phospho. |
+| `protwise/plotting/plotting.py` | Legacy/local plotting. `Plotter.plot_model_fit` hard-codes mRNA, protein, and phosphosite plotting and fixed time slices. |
+| `protwise/steady/` | Initial-condition helpers for local ODE models. |
+| `protwise/sensitivity/`, `protwise/knockout/` | Local sensitivity and knockout analyses, mostly downstream of a fitted model. |
+| `common/utils/display.py` | Shared local workflow output and report helpers. `save_result()` writes Excel sheets for fitted state solutions, site estimates, observations, PCA, t-SNE, and errors; `merge_obs_est()` currently merges only site observed/estimated sheets. |
+| `common/utils/tables.py`, `common/utils/latexit.py`, `common/utils/display.py` | Table, LaTeX, and report generation for local outputs. |
+
+### Configuration, CLI, processing, tests, docs, and scripts
+
+| File/folder | Apparent role |
+|---|---|
+| `config.toml` | Central user-facing configuration. Contains `[paths]`, `[ode]`, and `[networkmodel]` sections relevant here. It also contains KinOpt/TFOpt sections, which are excluded from this audit. |
+| `config_loader.py` | Root-level TOML loader. Provides `load()`, `ensure_dirs()`, `PhosKinConfig`, and `load_config_toml()`. `load_config_toml()` maps `[networkmodel]` keys into a dataclass. |
+| `config/config.py` | CLI argument parsing and config extraction for the legacy/local ODE workflow. It exposes `--input-excel-protein`, `--input-excel-psite`, and `--input-excel-rna`. |
+| `config/constants.py` | Constants derived from the `[ode]` config section, including ODE input paths, bounds, time points, output names, scoring weights, model type, sensitivity flags, and local workflow input defaults. |
+| `config/cli.py`, `__main__.py` | Typer CLI shortcuts. `networkmodel` runs `networkmodel.runner`; `model` runs the legacy runner; `all` runs prep and excluded KinOpt/TFOpt/local model sequence. Future multimodal global support should primarily affect `networkmodel`. |
+| `config/logconf.py` | Shared logging setup. Future mode messages should use this logger without changing logging infrastructure unless necessary. |
+| `processing/cleanup.py`, `processing/map.py` | Preprocessing/mapping helpers that create/transform network and data files. Relevant to examples and input expectations, but should not be required to change for internal mode inference. |
+| `tests/test_config.py` | Existing tests cover logging behavior only. Future tests should add global-model data-mode tests outside existing config tests. |
+| `docs/Documentation/*.md`, `docs/index.md`, `README.md`, `PYPI_README.md` | User-facing documentation. Current docs describe three-modality global fitting and the legacy/local workflow. Update after implementation only. |
+| `scripts/` | Standalone analysis/post-processing scripts that consume outputs. They should generally not be modified unless their assumptions break with mode-aware output files. |
+
+## 4. Current Data Flow
+
+### 4.1 CLI and configuration loading
+
+#### Global network model
+
+1. `config/cli.py` exposes a `networkmodel` command that runs `python -m networkmodel.runner --conf config.toml` through `_run()`/`_python_module()`.
+2. `networkmodel/config.py` imports `load_config_toml("config.toml")` from `config_loader.py` at import time and converts fields into module-level constants such as `KINASE_NET_FILE`, `MS_DATA_FILE`, `RNA_DATA_FILE`, `PHOSPHO_DATA_FILE`, `TIME_POINTS_PROTEIN`, `TIME_POINTS_RNA`, `TIME_POINTS_PHOSPHO`, model selection, solver tolerances, optimizer settings, lambdas, scaling, and weighting.
+3. `config_loader.load_config_toml(path)` reads the `[networkmodel]` table from `config.toml`. It maps:
+   - `kinase_net` to `PhosKinConfig.kinase_net`
+   - `tf_net` to `PhosKinConfig.tf_net`
+   - `ms` to `PhosKinConfig.ms_data`
+   - `rna` to `PhosKinConfig.rna_data`
+   - `phospho` to `PhosKinConfig.phospho_data`, defaulting to `ms` when absent or falsey
+   - `kinopt` and `tfopt` prior-result paths
+   - `[networkmodel.timepoints]` into protein/RNA/phospho time grids
+   - `[networkmodel.bounds]`, `[networkmodel.solver]`, optimizer, lambdas, scaling, weighting, sensitivity, and metadata.
+4. `networkmodel.runner.main()` separately defines argparse options with defaults imported from `networkmodel.config`, including `--ms`, `--rna`, `--phospho`, and lambda arguments. Important current behavior: `--phospho` is parsed but `networkmodel.io.load_data()` currently reads phospho from `args.ms`, not `args.phospho`.
+
+#### Legacy/local ODE model
+
+1. `config/cli.py` exposes a `model` command that runs `python -m runner.main`, but the repository path inspected here is `protwise/runner/main.py`. Documentation suggests `runner.main`; the actual module layout should be checked before implementation because there may be packaging aliases or historical paths.
+2. `protwise/runner/main.py` imports `parse_args()`, `extract_config()`, and `log_config()` from `config/config.py`.
+3. `config/config.py` reads defaults from `config/constants.py` and exposes CLI arguments for bounds, bootstraps, `--input-excel-protein`, `--input-excel-psite`, and `--input-excel-rna`.
+4. `config/constants.py` derives legacy/local input paths from `[ode.inputs]`: `protein_excel`, `psite_excel`, and `rna_excel`.
+
+### 4.2 Input file reading
+
+#### Global network model (`networkmodel/io.py`)
+
+`load_data(args)` currently performs the following:
+
+1. Loads `args.kinase_net` CSV, normalizes columns with `_normcols()`, finds topology columns by candidate names, expands comma/set kinase notations, and returns `df_kin_clean` with `protein`, `psite`, `kinase`.
+2. Optionally loads kinase prior alphas and betas from `args.kinopt` Excel sheets if the file exists; missing/failed loads are logged and filled/defaulted.
+3. Loads `args.tf_net` CSV, normalizes columns, finds TF/target columns, and optionally merges TF prior alphas/betas from `args.tfopt` Excel sheets.
+4. Loads mass-spec data from `args.ms` into `df_ms_raw`. It uses `process_and_scale_raw_data()` with `TIME_POINTS_PROTEIN`, `id_cols=["GeneID", "Psite"]`, and `SCALING_METHOD`. Then it normalizes columns, finds gene and psite columns, and reshapes either `x1..xN` wide columns or pre-melted `time`/`fc` columns.
+5. Splits the reshaped mass-spec tidy table into:
+   - `df_prot`: rows where `psite` is blank (`protein`, `time`, `fc`)
+   - `df_pho`: rows where `psite` is nonblank (`protein`, `psite`, `time`, `fc`)
+6. Loads RNA from `args.rna` CSV, normalizes columns, finds `geneid`/`mrna`/`gene`, renames it to `protein`, and uses `process_and_scale_raw_data()` with `TIME_POINTS_RNA` and `id_cols=["protein"]`.
+7. Returns `df_kin_clean`, `df_tf_clean`, `df_prot`, `df_pho`, `df_rna`, `kin_beta_map`, `tf_beta_map`.
+
+Current implication: global mode detection can happen immediately after `load_data()` returns, or inside `load_data()` after each layer is parsed. Since `load_data()` already creates distinct tidy layer data frames, it is the natural place to compute raw layer availability and validation metadata. `networkmodel.runner.main()` is the natural place to finalize the effective mode after filtering observations to the model index and mechanistic phosphosite pairs.
+
+#### Legacy/local ODE (`protwise/runner/main.py` and `protwise/paramest/core.py`)
+
+1. `protwise/runner/main.py` reads:
+   - protein data: `pd.read_csv(config['input_excel_protein'])`
+   - phosphosite/kinase data: `pd.read_excel(config['input_excel_psite'], sheet_name='Estimated')`
+   - mRNA data: `pd.read_excel(config['input_excel_rna'], sheet_name='Estimated')`
+2. It validates that both protein and phosphosite data collectively include `Gene`, `Psite`, and `x1..x14`, and that mRNA includes `mRNA` and `x1..x9`.
+3. It computes `common_proteins = sorted(set(kinase_data['Gene']).intersection(set(mrna_data['mRNA'])))`, then processes only those common proteins. This currently prevents mRNA-only, protein-only, phospho-only, mRNA+protein without phospho, and protein+phospho without mRNA in the legacy flow.
+4. `protwise/paramest/core.py::process_gene()` further extracts:
+   - protein rows where `protein_data['Psite'].isna()` and `GeneID == gene`
+   - phosphosite rows where `kinase_data['Gene'] == gene`
+   - RNA rows where `mrna_data['mRNA'] == gene`
+   It then slices values by fixed positional columns and passes all arrays into `estimate_parameters()`.
+
+### 4.3 Preprocessing and normalization
+
+#### Global network model
+
+- `networkmodel.utils._normcols()` lowercases and normalizes column names.
+- `networkmodel.utils._find_col()` returns the first matching candidate column but returns `None` if none is found; several callers assume the returned column is valid, so missing columns can fail later with less explicit errors.
+- `networkmodel.utils.process_and_scale_raw_data()` expects wide `x1`, `x2`, ... columns. It supports scaling methods `raw`/`none`, `fc_start`, `robust_fc`, `max_scale`, `mean_scale`, and `l2_norm`, then melts to tidy `id_cols + [time, fc]`.
+- `networkmodel.utils.normalize_fc_to_t0()` can normalize protein/phospho data by a t=0 baseline. In `runner.main()`, this is currently applied only to `df_prot` and `df_pho`, not RNA.
+- `networkmodel.runner.main()` applies a strict mechanistic phospho filter, dropping any `(protein, psite)` in `df_pho` not represented in `df_kin`.
+- `networkmodel.runner.main()` restricts all observations to `idx.proteins` after building the model index.
+- `networkmodel.optproblem.build_weight_functions()` builds time-dependent weights. `runner.main()` currently applies one protein/phospho weight function to both `df_prot` and `df_pho`, and a separate RNA weight function to `df_rna`. Although config has `weighting_method_phospho`, the current runner imports it but does not use it separately.
+
+#### Legacy/local model
+
+- `protwise/runner/main.py` assumes input tables already contain the expected `x1..x14` and `x1..x9` columns and does not use the global `process_and_scale_raw_data()` utility.
+- `protwise/paramest/core.py` uses positional slicing (`iloc[:, 2:]` for protein/phospho, `iloc[:, 1:]` for mRNA), so the order and count of columns are critical.
+- `protwise/models/distmod.py::solve_ode()` optionally normalizes model output if `NORMALIZE_MODEL_OUTPUT` is true.
+
+### 4.4 Model setup and ODE solving
+
+#### Global network model
+
+1. `networkmodel.runner.main()` builds `df_tf_model` using TF proxy logic and constructs `idx = Index(df_kin, tf_interactions=df_tf_model, ...)`.
+2. `networkmodel.network.Index` defines the state-vector layout. For non-combinatorial models, each protein has `[mRNA_i, protein_i, phosphosite_1, ..., phosphosite_n]`. For combinatorial models, each protein has `[mRNA_i, protein_state_0, ..., protein_state_2^n]`.
+3. `networkmodel.network.KinaseInput` builds a piecewise-constant kinase activity matrix from `df_prot`, defaulting to ones for missing kinases.
+4. `networkmodel.buildmat.build_W_parallel()` and `build_tf_matrix()` construct sparse kinase-substrate and TF matrices.
+5. `networkmodel.network.System` stores parameters, matrices, kinase input, optional data-derived initial conditions, and RHS packing for Numba/ODE solvers.
+6. `networkmodel.simulate.simulate_odeint()` uses either the custom solver or `scipy.integrate.odeint` over the union time grid.
+7. `networkmodel.simulate.simulate_and_measure()` extracts predicted fold-change tables for all three observable layers from a simulated trajectory.
+
+#### Legacy/local model
+
+1. `protwise.paramest.core.process_gene()` calls `protwise.steady.initial_condition(num_psites)`.
+2. `protwise.paramest.toggle.estimate_parameters()` dispatches to the selected parameter-estimation routine.
+3. Model solvers in `protwise/models/*.py` solve a per-protein ODE over `TIME_POINTS` and return a flattened output containing mRNA, protein, and phosphosite predictions.
+4. `protwise.models.distmod.solve_ode()` returns `sol` and `np.concatenate((R_fitted.flatten(), Pr_fitted.flatten(), P_fitted.flatten()))`, where `R_fitted` currently uses `sol[5:, 0]` and therefore implicitly assumes a fixed offset between protein/phospho and RNA time grids.
+
+### 4.5 Objective/loss creation and optimization
+
+#### Global network model
+
+1. `runner.main()` creates `solver_times = np.unique(np.concatenate([TIME_POINTS_PROTEIN, TIME_POINTS_RNA, TIME_POINTS_PHOSPHO]))`.
+2. `networkmodel.cache.prepare_fast_loss_data(idx, df_prot, df_rna, df_pho, solver_times)` maps each tidy data frame into integer arrays:
+   - protein: `p_prot`, `t_prot`, `obs_prot`, `w_prot`
+   - RNA: `p_rna`, `t_rna`, `obs_rna`, `w_rna`
+   - phospho: `p_pho`, `s_pho`, `t_pho`, `obs_pho`, `w_pho`
+   - state metadata: `prot_map`, `n_p`, `n_r`, `n_ph`
+3. Counts are currently returned as `max(1, len(obs_*))`, which hides empty layers as count `1`. This is risky for mode detection and logging.
+4. `networkmodel.lossfn.LOSS_FN` computes raw protein, RNA, and phospho loss sums by looping over the arrays for each modality. Empty arrays naturally produce zero sums, but downstream objective assembly still creates three objectives.
+5. `networkmodel.optproblem.GlobalODE_MOO` is fixed to `n_obj=3`. It computes normalizers as inverse sums of `w_prot`, `w_rna`, and `w_pho`, guarded by `max(1e-6, sum(weights))`.
+6. It returns `[protein_obj + prior_penalty, rna_obj + prior_penalty, phospho_obj + prior_penalty]` regardless of whether any layer has observations.
+7. The Pymoo path then runs `UNSGA3`, saves `pareto_X.npy`, `pareto_F.npy`, `pareto_F.csv`, and exports Pareto front Excel.
+8. The Optuna path (`networkmodel/optuna_solver.py`) uses `_augment_loss_data()` and `NativeOptunaObjective`. This path appears inconsistent with `prepare_fast_loss_data()` because `NativeOptunaObjective._build_fast_indices()` expects keys such as `prot_idx`, `prot_target`, `rna_idx`, and `pho_idx`, while `prepare_fast_loss_data()` returns `p_prot`, `obs_prot`, etc. If Optuna is used, it likely needs careful revalidation even before multimodal support.
+
+#### Legacy/local model
+
+1. `protwise.paramest.normest.parameter_estimation()` creates `target = np.concatenate([r_data.flatten(), pr_data.flatten(), p_data.flatten()])`.
+2. If regularization is enabled, it appends zeros to form `target_fit`.
+3. `model_func()` calls `solve_ode()` and returns the same fixed flattened output, optionally appended with regularization terms.
+4. `curve_fit()` is called with that fixed target length. Missing layers would currently produce shape mismatches or empty segments unless explicitly handled.
+5. Scoring uses `score_fit()` over the same fixed full target vector.
+
+### 4.6 Result extraction, plotting, saving, reports, logging
+
+#### Global network model
+
+- After optimization, `runner.main()` selects a solution by weighted Fréchet score across protein, RNA, and phospho observations. It currently initializes all three Fréchet components and detailed-score dictionaries and loops over each layer if predictions and observed data are nonempty.
+- It saves raw picked predictions to `pred_prot_picked.csv`, `pred_rna_picked.csv`, and `pred_phospho_picked.csv` whenever `simulate_and_measure()` returns non-`None` data frames. Because `simulate_and_measure()` always constructs protein and RNA prediction rows for all modeled proteins, these files are currently written even if no corresponding observed layer was fitted.
+- It writes `picked_objectives.json` with `prot_mse`, `rna_mse`, `phospho_mse`, and `scalar_score` for all three layers.
+- It calls `plot_goodness_of_fit(df_prot, dfp, df_rna, dfr, df_pho, dfph, ...)`. This function merges all three observed/predicted pairs and then concatenates them. If a layer is empty, empty merges are fine, but if all are empty or a prediction data frame is unexpectedly empty, plotting can fail when calculating min/max/regression.
+- It generates per-gene time-series plots through `save_gene_timeseries_plots()` for every `idx.proteins`, with three panels always created for protein, mRNA, and phosphorylation.
+- It calls `export_residuals()`, `export_parameter_distributions()`, `export_S_rates()`, `plot_s_rates_report()`, `export_results()`, Pareto plots, convergence video, prior regularization scan, and dashboard bundle save. Several of these assume three objective columns or all layers.
+- It logs many details but does not currently log a detected data mode, skipped optional layers, or layer-specific data shapes after filtering.
+
+#### Legacy/local model
+
+- `common.utils.display.save_result()` writes per-gene Excel sheets including parameters, errors, fitted state solution, site estimates, site observations, PCA, t-SNE, and potentially sensitivity/knockout data.
+- `common.utils.display.merge_obs_est()` currently merges only `*_site_observed` and `*_site_estimates`, so local goodness-of-fit reporting is phosphosite-centric even though fitting includes mRNA and protein.
+- `protwise.plotting.Plotter.plot_model_fit()` creates fixed mRNA/protein/phosphosite plots and hard-codes data slicing for 9 RNA points and 14 protein/phospho points.
+- The legacy runner logs common genes, missing required columns, metric definitions, and output report path, but not a mode.
+
+## 5. Current Assumptions About Input Data
+
+### Global network model assumptions
+
+- `args.kinase_net` is a CSV with columns discoverable as gene/protein, psite/site, and kinase/k.
+- `args.tf_net` is a CSV with TF/source and target columns discoverable by candidate names.
+- `args.ms` is required and contains both protein abundance rows and phosphosite rows in one table, distinguishable by whether `Psite` is blank.
+- `args.phospho` exists in config/CLI but is not effectively used by `networkmodel.io.load_data()` today; `phospho` in config defaults to `ms`.
+- Protein/phospho mass-spec wide columns are expected as `x1..xN` mapped to `TIME_POINTS_PROTEIN`; alternatively a pre-melted format with `time` and `mean`/`fc` is accepted in part of `load_data()`.
+- RNA is required from `args.rna`, with a gene column discoverable as `geneid`, `mrna`, or `gene`, plus `x1..xN` columns mapped to `TIME_POINTS_RNA` by `process_and_scale_raw_data()`.
+- Protein identifiers are uppercased in mass-spec processing. RNA identifiers are renamed to `protein` by `process_and_scale_raw_data()`, which uppercases ID columns at the end. Network identifiers are uppercased during kinase-network expansion for `protein` and `kinase`.
+- Phosphosite names are stripped but not systematically uppercased; site matching is exact after stripping.
+- Missing observation values are coerced to numeric and dropped in mass-spec preprocessing. RNA preprocessing also coerces values during scaling/melting; exact drop behavior is in `process_and_scale_raw_data()`.
+- `df_pho` is filtered to `(protein, psite)` pairs present in the kinase network, so phospho data outside the mechanistic network is silently removed except for a count log.
+- `df_prot`, `df_rna`, and `df_pho` are filtered to proteins in `idx.proteins` after model-index construction.
+- Time values in observations must exactly map to `solver_times`; `prepare_fast_loss_data()` raises if a time is not present in the union grid.
+- The state vector always includes an mRNA state and protein/phospho states for each modeled protein. The model therefore already has the structural basis for all data modes.
+- The optimizer currently assumes three objectives and names them `prot_mse`, `rna_mse`, and `phospho_mse` regardless of data availability.
+- Layer weights are supported by existing lambda values (`lambda_protein`, `lambda_rna`, `lambda_phospho`) and time weighting methods, but no explicit mode-aware disabling exists.
+- `TIME_POINTS_PHOSPHO` is available in the config, but current `load_data()` maps both protein and phospho rows from `args.ms` using `TIME_POINTS_PROTEIN`; the future implementation should resolve this ambiguity.
+
+### Legacy/local workflow assumptions
+
+- Protein input is a CSV. Phosphosite and mRNA inputs are Excel files with `Estimated` sheets.
+- Protein-only rows are identified by `Psite.isna()` and `GeneID == gene`.
+- Phosphosite rows are identified by `Gene == gene`, with one row per psite and fixed `x1..x14` columns.
+- mRNA rows are identified by `mRNA == gene`, with fixed `x1..x9` columns.
+- Only genes present in both phosphosite and mRNA data are processed. Protein-only availability does not contribute to gene selection.
+- The target vector order is fixed: mRNA first, protein second, phosphosite rows third.
+- The model-output vector length is fixed to match the full three-layer target. Missing layers are not supported.
+- `Plotter.plot_model_fit()` assumes exactly 9 RNA points, 14 protein points, and 14 phospho points per site.
+- `save_result()` and `merge_obs_est()` are primarily phosphosite-sheet oriented for observed/estimated output merging.
+
+## 6. Desired Future Data Modes
+
+For all modes, the core model should remain structurally consistent. The internal state can continue to include mRNA, protein, and phosphosite states; mode affects only which observations are validated, fitted, plotted, saved as fitted predictions, and reported as objective terms.
+
+### 6.1 mRNA only
+
+- Required input data: nonempty RNA table after loading, identifier normalization, time mapping, and model-index filtering.
+- Unavailable data: no protein observations and no phospho observations.
+- Model outputs compared: predicted RNA/mRNA fold-change only (`R(t)`/state offset `start`).
+- Loss terms: include RNA loss only; protein and phospho losses must be skipped, not replaced with fake zeros that affect objectives.
+- Plotting: mRNA observed vs predicted goodness-of-fit and mRNA time-series plots only. No protein/phospho panels except optional clearly labeled model-simulation diagnostics not counted as fit outputs.
+- Tables/files: save `pred_rna_picked.csv`, picked RNA objective, mode metadata, model parameters, and any generic network matrices. Do not create fitted protein/phospho prediction files unless explicitly categorized as unfitted simulation diagnostics.
+- Logs: `Detected data mode: mrna_only`; `Fitting layers: mRNA`; `Skipped layers: protein, phospho`; shape of `df_rna` before/after filtering.
+- Edge cases: RNA identifiers may not appear in kinase-network-derived `idx.proteins` unless TF edges or topology include them; mode detection should distinguish raw RNA present from effective RNA after model filtering. If all RNA rows are filtered out, fail with an explicit error.
+
+### 6.2 protein only
+
+- Required input data: nonempty protein abundance rows after loading and filtering.
+- Unavailable data: no RNA observations and no phospho observations.
+- Model outputs compared: predicted total protein fold-change only (`P_unphos + sum(P_phos)` or combinatorial state sum).
+- Loss terms: include protein loss only.
+- Plotting: protein observed vs predicted goodness-of-fit and protein time-series plots only.
+- Tables/files: save `pred_prot_picked.csv`, picked protein objective, mode metadata, and generic model/network outputs.
+- Logs: `Detected data mode: protein_only`; `Fitting layers: protein`; skipped RNA/phospho layers.
+- Edge cases: protein-only mode still needs a network/model universe. If a protein has no site/network representation, the current `Index` may not include it unless topology includes it; future validation should report unsupported observed proteins rather than silently dropping all rows.
+
+### 6.3 phospho only
+
+- Required input data: nonempty phosphosite observations after mechanistic `(protein, psite)` filtering and model-index filtering.
+- Unavailable data: no mRNA or protein abundance observations.
+- Model outputs compared: predicted phosphosite fold-change only (`P_site_j(t)` or combinatorial site aggregation).
+- Loss terms: include phospho loss only.
+- Plotting: phosphosite observed vs predicted plots; per-site time-series panels only.
+- Tables/files: save `pred_phospho_picked.csv`, picked phospho objective, S-rate files/reports where meaningful, and mode metadata.
+- Logs: `Detected data mode: phospho_only`; dropped phosphosite count from mechanistic filter; skipped RNA/protein layers.
+- Edge cases: current `KinaseInput` uses `df_prot` and defaults to flat kinase inputs if protein data is absent. That should be logged because phospho-only fitting may rely on default kinase drivers.
+
+### 6.4 mRNA + protein
+
+- Required input data: nonempty RNA and protein observations after filtering.
+- Unavailable data: no phosphosite observations.
+- Model outputs compared: RNA and total protein fold-change.
+- Loss terms: include RNA and protein losses; skip phospho loss.
+- Plotting: separate RNA and protein plots, plus optional combined two-layer goodness-of-fit.
+- Tables/files: save `pred_rna_picked.csv`, `pred_prot_picked.csv`, combined summary with RNA/protein objectives, no fitted phospho predictions unless diagnostic-only.
+- Logs: detected mode, available layers, skipped phospho, per-layer shapes.
+- Edge cases: a topology with no modeled sites still has mRNA/protein states; if `df_kin` is required to build `Index`, mRNA/protein-only use may need a clear rule for representing proteins that appear only in observations/TF targets.
+
+### 6.5 mRNA + phospho
+
+- Required input data: nonempty RNA and phosphosite observations after filtering.
+- Unavailable data: no protein abundance observations.
+- Model outputs compared: RNA and phosphosite fold-change.
+- Loss terms: include RNA and phospho losses; skip protein loss.
+- Plotting: RNA and phospho plots; optional combined two-layer diagnostics.
+- Tables/files: save `pred_rna_picked.csv`, `pred_phospho_picked.csv`, S-rate reports, combined summary.
+- Logs: detected mode, skipped protein, and warning that kinase input trajectories default to flat values for kinases without protein observations.
+- Edge cases: data-derived initial conditions currently use protein totals to allocate phospho mass; if protein is unavailable and `use_initial_condition_from_data=true`, y0 construction must use safe defaults for total protein and log that choice.
+
+### 6.6 protein + phospho
+
+- Required input data: nonempty protein and phosphosite observations after filtering.
+- Unavailable data: no RNA observations.
+- Model outputs compared: total protein and phosphosite fold-change.
+- Loss terms: include protein and phospho losses; skip RNA loss.
+- Plotting: protein and phospho plots; optional combined two-layer diagnostics.
+- Tables/files: save `pred_prot_picked.csv`, `pred_phospho_picked.csv`, S-rate reports, combined summary.
+- Logs: detected mode and skipped RNA.
+- Edge cases: transcription parameters `A_i`/`B_i` remain part of the structural model even if RNA is not fitted. Regularization/bounds should prevent unconstrained RNA dynamics from destabilizing protein/phospho states.
+
+### 6.7 mRNA + protein + phospho
+
+- Required input data: all three layers nonempty after filtering.
+- Unavailable data: none.
+- Model outputs compared: RNA, total protein, and phosphosite fold-change.
+- Loss terms: current intended full behavior; include all three losses.
+- Plotting: current combined goodness-of-fit plus per-layer plots and per-gene three-panel time-series plots.
+- Tables/files: preserve current outputs and names where possible.
+- Logs: detected mode `mrna_protein_phospho` or `all_layers`; no skipped layers.
+- Edge cases: this mode is the backward-compatibility baseline and should be used as the first regression target.
+
+## 7. Recommended Internal Mode Detection Design
+
+### 7.1 Where detection should happen
+
+Use a two-stage detection approach:
+
+1. **Raw layer detection in `networkmodel.io.load_data()` after each layer is parsed.** This detects whether RNA, protein, and phospho files/rows are present before model-specific filtering. It should also capture source path, raw row count, tidy row count, identifiers, time columns/time values, and parsing warnings.
+2. **Effective fit-mode finalization in `networkmodel.runner.main()` after mechanistic phospho filtering and filtering observations to `idx.proteins`.** This is the mode that should control loss construction and downstream outputs because it reflects what can actually be fitted.
+
+For the legacy/local workflow, equivalent detection would happen after `protwise/runner/main.py` loads the three input tables and again after `protwise/paramest/core.py` extracts per-gene arrays. However, the safest first implementation target should be the global `networkmodel` pipeline because it already has separate tidy data frames and a separate loss array per layer.
+
+### 7.2 Recommended metadata object
+
+Create a small internal object; do not add config keys. A dataclass is a good fit:
+
+```python
+@dataclass(frozen=True)
+class DataMode:
+    available_layers: tuple[str, ...]          # e.g. ("rna", "protein", "phospho")
+    fit_mrna: bool
+    fit_protein: bool
+    fit_phospho: bool
+    mode_name: str                             # e.g. "mrna_protein"
+    raw_counts: dict[str, int]
+    filtered_counts: dict[str, int]
+    identifiers: dict[str, set[str]]
+    timepoints: dict[str, np.ndarray]
+    skipped_layers: tuple[str, ...]
+    warnings: tuple[str, ...]
+```
+
+Layer names should be standardized internally as `"mrna"`, `"protein"`, and `"phospho"`. If keeping current variable names, map them carefully:
+
+- `df_rna` -> `mrna`
+- `df_prot` -> `protein`
+- `df_pho` -> `phospho`
+
+### 7.3 Inference rules without config schema changes
+
+Recommended rules:
+
+1. Use existing configured paths only:
+   - RNA source: `[networkmodel].rna` / `args.rna`
+   - protein source: `[networkmodel].ms` / `args.ms`, blank `Psite` rows
+   - phospho source: `[networkmodel].phospho` / `args.phospho` if it exists and is distinct; otherwise `[networkmodel].ms` / `args.ms` nonblank `Psite` rows
+2. Preserve old behavior when `phospho` is absent or equal to `ms`: split the mass-spec table by blank/nonblank `Psite`.
+3. If `phospho` is present and distinct from `ms`, read protein abundance from `ms` and phospho observations from `phospho` using the same accepted wide/pre-melted rules. This uses an existing config key that already exists; it is not a schema change.
+4. Treat a layer as available only if, after parsing and cleaning, it has at least one finite `fc` value, at least one valid `time`, and at least one identifier.
+5. Treat a layer as fit-enabled only if it remains nonempty after all model-index and mechanistic filtering.
+6. If raw data are present but all rows are filtered out, log a warning and either fail if no other layer remains, or continue with the remaining layers while recording the layer as skipped due to incompatibility.
+7. If no layer remains fit-enabled, fail before optimization with a clear error.
+
+### 7.4 Downstream consumption
+
+Every downstream function should consume mode through one of two patterns:
+
+- Pass `data_mode` explicitly where needed (`prepare_fast_loss_data`, `GlobalODE_MOO`, export/plot functions), or
+- Store it in a normalized data bundle object passed around the runner.
+
+Avoid having downstream functions infer mode independently from data-frame emptiness in multiple places. That creates inconsistent behavior. The source of truth should be the finalized `DataMode` after filtering.
+
+### 7.5 Safe failure behavior
+
+- Missing optional layer file: skip if other layers are available and log it as unavailable, not as an error.
+- Missing required columns in a file that is intended to supply a layer: error for that layer; continue only if the file is clearly optional and other valid layers exist.
+- Ambiguous file content: log the rule used, e.g. `Psite blank rows treated as protein; nonblank Psite rows treated as phospho`.
+- Data present but all filtered out: warn with before/after counts and fail if no fit layers remain.
+- Duplicate layer sources: allow `ms == phospho` as current behavior; if separate paths contain overlapping phospho rows, deduplicate by `(protein, psite, time)` and log duplicates.
+
+## 8. Recommended Model Output Interface
+
+The model already structurally exposes the needed states:
+
+- mRNA: first state in each protein block (`Y[:, offset_y[i]]`)
+- protein: total protein computed from unphosphorylated + phosphosite states or from the sum of combinatorial protein states
+- phospho: per-site phosphorylated states or bitwise aggregation for combinatorial states
+
+The future implementation should formalize this in a consistent observable interface rather than scattering extraction logic across `lossfn.py`, `simulate.py`, and `optuna_solver.py`.
+
+Recommended interface:
+
+```python
+@dataclass
+class ModelObservables:
+    rna: pd.DataFrame | None       # columns: protein, time, pred_fc
+    protein: pd.DataFrame | None   # columns: protein, time, pred_fc
+    phospho: pd.DataFrame | None   # columns: protein, psite, time, pred_fc
+```
+
+or, for performance-sensitive code:
+
+```python
+extract_observables(Y, idx, time_grid, layers, baseline_times) -> dict[str, np.ndarray | pd.DataFrame]
+```
+
+Functions needing adjustment:
+
+- `networkmodel.simulate.simulate_and_measure()` should accept a `layers`/`data_mode` argument and return only requested layers for fitted-output contexts. It may still support all-layer extraction for diagnostics if explicitly requested.
+- `networkmodel.lossfn.loss_function_noncomb()` and `loss_function_comb()` can continue to compute separate raw losses from arrays, but the caller should decide which losses become objectives.
+- `networkmodel.optuna_solver._augment_loss_data()` should be replaced or aligned with `prepare_fast_loss_data()` and the same observable definitions. Its current direct state-index approach does not match fold-change observable extraction for total protein/combinatorial phospho.
+- `protwise/models/*.py::solve_ode()` currently returns a fixed flattened vector. If the legacy workflow is made mode-aware later, it should return structured observables or accept a mask specifying which segments to concatenate.
+- `protwise/plotting/plotting.py::plot_model_fit()` should not parse fixed slices from a flattened vector; it should consume a structured observable result.
+
+## 9. Recommended Loss Construction
+
+### 9.1 Global network model
+
+Keep the low-level loss kernels capable of returning three raw loss sums, but make objective assembly mode-aware.
+
+Recommended steps:
+
+1. `prepare_fast_loss_data()` should return true counts, not `max(1, len(obs_*))`, plus an explicit `available_layers` or `fit_layers` list.
+2. For each available layer:
+   - Validate observation arrays, time indices, weights, and predicted observable shape.
+   - Compute residual using the existing layer-specific logic.
+   - Apply the existing time weights and layer lambda (`lambda_rna`, `lambda_protein`, `lambda_phospho`).
+   - Normalize by the sum of weights for that available layer.
+3. For unavailable layers:
+   - Pass empty arrays to low-level kernels if convenient, but do not create an optimization objective for that layer unless preserving a fixed 3-objective external shape is explicitly chosen for compatibility.
+   - Do not fill targets with zeros.
+   - Do not use fake counts.
+   - Do not include that layer in scalar score, Fréchet selection, plots, or fitted-output files.
+4. Prior regularization should remain available. If objectives are dynamic, either add the same prior penalty to each active objective or include it only in scalar ranking. Preserve current behavior for all-three mode by adding it to all three active objectives.
+
+### 9.2 Objective shape choice
+
+There are two viable designs:
+
+#### Option A: Dynamic objective count
+
+- `GlobalODE_MOO.n_obj = len(data_mode.available_layers)`.
+- `F` columns correspond only to active layers.
+- Pros: no fake objectives; optimizer focuses only on active data.
+- Cons: more output code changes; Pymoo reference directions, Pareto CSV columns, Pareto plots, lambda scans, and dashboards must become dynamic.
+
+#### Option B: Fixed 3 objective columns with inactive objectives masked
+
+- Keep `n_obj=3`, but inactive objectives are excluded from selection/scoring and marked `NaN` or a sentinel in output.
+- Pros: less optimizer/export disruption.
+- Cons: Pymoo still optimizes inactive dimensions if they are finite constants; `NaN` may break algorithms; constants can distort Pareto ranking/reference directions.
+
+Recommendation: implement dynamic active objectives internally, and write compatibility outputs that include all three named columns with `NaN` for unavailable layers only after optimization. This avoids optimizing fake objectives while keeping old output names where feasible.
+
+### 9.3 Layer-specific weights
+
+Current global code supports:
+
+- `lambda_protein`, `lambda_rna`, `lambda_phospho`
+- `weighting_method_protein`, `weighting_method_rna`, and a config value `weighting_method_phospho`
+
+But `runner.main()` currently applies the protein weighting method to both protein and phospho. Future code should use `WEIGHTING_METHOD_PHOSPHO` for `df_pho` if the existing config loader exposes it. This uses an existing schema field, not a new one.
+
+## 10. Recommended Optimization Impact
+
+### Current optimizer expectations
+
+- `GlobalODE_MOO` expects one parameter vector and returns exactly three objectives.
+- `UNSGA3` reference directions are built with `problem.n_obj`.
+- `pareto_F.csv`, `picked_objectives.json`, `export_pareto_front_to_excel()`, `save_pareto_3d()`, `save_parallel_coordinates()`, `scan_prior_reg()`, and dashboard bundle code assume `F` has columns `[prot_mse, rna_mse, phospho_mse]`.
+- Solution selection uses weighted Fréchet distance across all available observed data frames but initializes all three components.
+- The parameter vector includes `c_k`, `A_i`, `B_i`, `C_i`, `D_i`, `Dp_i`, `E_i`, and `tf_scale` regardless of layer availability.
+
+### Required future changes
+
+- Add `data_mode` or `active_layers` to `GlobalODE_MOO` and any Optuna objective.
+- Change objective assembly to return only active layer objectives.
+- Maintain a mapping such as `objective_names = ["protein_mse", "rna_mse"]` for active modes.
+- Use dynamic objective names when writing Pareto CSV/Excel and picked objectives.
+- For backward compatibility, optionally include a separate `picked_objectives_all_layers.json` with inactive layers as `null`/`NaN`, while keeping existing `picked_objectives.json` schema in all-three mode.
+- Ensure Pymoo reference directions use the active objective count.
+- Make `save_pareto_3d()` conditional: only call it when exactly three active objectives exist; otherwise call a 2D or 1D plotting function or skip with a log message.
+- Make `scan_prior_reg()` dynamic or skip it when not all three objectives exist.
+- Optuna solver should be audited/fixed separately because its current indexing appears inconsistent with the global loss-data structure.
+
+### Parameter vector, bounds, constraints, initial guesses
+
+- The core parameter vector should remain structurally unchanged to preserve model consistency.
+- Bounds from `calculate_bio_bounds(idx, df_prot, df_rna, tf_mat, kin_in)` may need mode-aware handling if it currently relies on a missing `df_prot` or `df_rna` to estimate ranges. Missing layers should fall back to defaults, not fail silently.
+- `KinaseInput` already falls back to flat ones if protein data is empty; this should be logged as a mode-specific assumption.
+- Data-derived initial conditions in `build_y0_from_data()` already defaults missing RNA/protein/phospho entries to `1.0`/`0.0`; this should become explicit validation/logging when layers are absent.
+
+## 11. Recommended Plotting Changes
+
+### Global plotting functions needing changes
+
+- `networkmodel.export.plot_goodness_of_fit()` should accept `data_mode` and skip unavailable layers before merging. It should fail only if no active layer has matched observed/predicted rows.
+- `networkmodel.export.save_gene_timeseries_plots()` currently creates a fixed three-panel plot. It should create one panel per active fitted layer or clearly gray/label skipped layers if compatibility is desired.
+- `networkmodel.export.save_pareto_3d()` should run only for three active objectives.
+- `networkmodel.export.save_parallel_coordinates()` should use dynamic objective names.
+- `networkmodel.export.plot_gof_from_pareto_excel()` should not require sheets for unavailable trajectory layers.
+- Dashboard plotting in `networkmodel/dashboard_app.py` should read mode metadata and hide unavailable layers.
+- Legacy `protwise.plotting.Plotter.plot_model_fit()` should be made mode-aware only if the local workflow is targeted later.
+
+### Mode-specific plotting behavior
+
+| Mode | Plotting outputs |
+|---|---|
+| mRNA only | mRNA observed-vs-predicted scatter and mRNA time-series plots. No fitted protein/phospho panels. |
+| protein only | Protein observed-vs-predicted scatter and protein time-series plots. |
+| phospho only | Phosphosite observed-vs-predicted scatter and per-site time-series plots. |
+| mRNA + protein | Separate mRNA/protein plots plus combined two-layer diagnostic. |
+| mRNA + phospho | Separate mRNA/phospho plots plus combined two-layer diagnostic. |
+| protein + phospho | Separate protein/phospho plots plus combined two-layer diagnostic. |
+| all three | Preserve current combined and per-modality plots. |
+
+## 12. Recommended Saving and Output Changes
+
+### Global saving functions needing changes
+
+- `networkmodel.runner.main()` should write picked prediction files only for fitted layers unless a file is explicitly named as an unfitted simulation diagnostic.
+- `picked_objectives.json` should be dynamic or include inactive layers as `null`. In all-three mode, preserve current keys and semantics.
+- `pareto_F.csv` should use active objective columns. For compatibility, optionally write `pareto_F_all_layers.csv` with inactive layer columns as `NaN`.
+- `networkmodel.export.export_pareto_front_to_excel()` should create trajectory sheets only for active fitted layers. If preserving sheet names, empty sheets should include a note or be omitted with metadata.
+- `networkmodel.export.export_results()` currently saves model parameters and layer outputs; it should not require all three predicted/observed tables to be nonempty before export.
+- `networkmodel.export.export_residuals()` should export residuals only for active layers.
+- `networkmodel.dashboard_bundle.save_dashboard_bundle()` should include `data_mode` metadata, active objective names, and per-layer row counts.
+- `common.utils.display.save_result()` and `merge_obs_est()` require analogous changes if local mode-aware support is implemented later.
+
+### Recommended files/metadata
+
+- Save a small `data_mode.json` in the output directory:
+
+```json
+{
+  "mode_name": "mrna_protein_phospho",
+  "available_layers": ["mrna", "protein", "phospho"],
+  "fit_layers": ["mrna", "protein", "phospho"],
+  "raw_counts": {"mrna": 100, "protein": 100, "phospho": 250},
+  "filtered_counts": {"mrna": 90, "protein": 95, "phospho": 220},
+  "skipped_layers": [],
+  "warnings": []
+}
+```
+
+- Keep existing output paths unchanged for the current all-three mode.
+- Avoid writing misleading empty prediction files for skipped layers.
+- If diagnostic simulations for skipped layers are useful, place them under a distinct name such as `diagnostic_pred_protein_unfitted.csv` and log that they were not fitted.
+
+## 13. Recommended Logging and Console Messages
+
+### Current logging hooks
+
+- `config.logconf.setup_logger()` provides the logging infrastructure.
+- `networkmodel.runner.main()` logs application metadata, solver/model choice, arguments, network/filter counts, optimization settings, outputs, and final parameters.
+- `networkmodel.io.load_data()` logs file loads and prior-load warnings.
+- `networkmodel.network.Index` logs model dimensions and proxy rewiring.
+- `protwise/runner/main.py` logs local configuration, common genes, per-gene processing, plotting, LaTeX/report generation, and report path.
+
+### Future required messages
+
+At minimum, global mode-aware implementation should log:
+
+- Raw detected layer availability and source paths.
+- Effective fit mode after all filtering.
+- Available/fitted layers and skipped layers.
+- Raw and filtered row counts per layer.
+- Unique identifier counts per layer.
+- Timepoints detected per layer and configured time grids used.
+- Loss terms included and excluded.
+- Objective names and optimizer objective count.
+- Whether kinase inputs are data-driven or default flat because protein data is absent.
+- Whether data-derived initial conditions used defaults for unavailable layers.
+- Which output files were generated per layer.
+- Warnings for optional missing layers.
+- Errors for malformed files, missing required columns in present files, invalid times, and no active fit layers.
+
+Example global log block:
+
+```text
+[Mode] Raw layers detected: mRNA=yes (900 rows), protein=no (0 rows), phospho=yes (4200 rows)
+[Mode] Effective fit mode after filtering: mrna_phospho
+[Mode] Fitting layers: mRNA, phospho
+[Mode] Skipped layers: protein (no blank-Psite protein rows in ms input)
+[Loss] Active objectives: rna_mse, phospho_mse
+[Output] Writing fitted predictions for: rna, phospho
+```
+
+## 14. Validation Rules Needed
+
+### File-level validation
+
+- Existing configured path points to a readable file if the layer is expected from that path.
+- Empty files should be reported as empty layer sources, not passed downstream to pandas/optimizer without context.
+- If `ms` and `phospho` are the same path, split by `Psite` as current behavior.
+- If `phospho` is distinct, parse it independently and apply the phospho time grid or documented inference rule.
+
+### Column validation
+
+- Protein/mass-spec input: require a gene/protein identifier column and either wide `x1..xN` columns or pre-melted `time` plus `fc`/`mean`.
+- Mixed protein/phospho input: `Psite`/`site` column should be present to split layers. If absent, classify as protein-only unless the file is explicitly the `phospho` source; if explicitly phospho, error.
+- RNA input: require gene/mRNA identifier and time/value columns.
+- Network input: require protein/gene, psite/site, and kinase columns.
+- TF input: require TF/source and target columns if nonempty.
+
+### Time validation
+
+- Observed times must map to configured layer time grids or to the solver union grid after rounding/normalization.
+- If wide column count exceeds configured time points, current code truncates columns; future code should log this explicitly.
+- If wide column count is less than configured time points, log the mapping used and avoid assuming missing timepoints are zero.
+- RNA and phospho baseline times (`4.0` for RNA, `0.0` for protein/phospho currently) should be present or selected by a documented nearest-time rule.
+
+### Identifier validation
+
+- Normalize protein/gene identifiers consistently across RNA, protein, phospho, kinase network, and TF network.
+- Report identifiers present in observations but absent from `idx.proteins` before filtering them out.
+- For combined modes, do not require all layers to share identical identifier sets; fit each layer for its available identifiers.
+- For phosphosite data, validate `(protein, psite)` pairs against the model site map and report dropped sites.
+- Duplicated `(layer, protein, time)` or `(phospho, protein, psite, time)` rows should be resolved by a clear rule, preferably average or last with a warning.
+
+### Numeric validation
+
+- Coerce `fc` and `time` columns to numeric and drop or error on missing values according to layer policy.
+- Reject nonfinite observations after preprocessing.
+- Prevent zero or negative baselines from creating NaNs/infs in fold-change calculations.
+- Validate weights are finite, nonnegative, and nonempty for active layers.
+
+### Mode validation
+
+- Valid effective modes are exactly the seven nonempty combinations.
+- If zero effective layers remain, fail before model construction or before optimization with a clear error.
+- If raw layer is present but effective layer is absent, log the reason and do not include it in the loss.
+- If a layer is unavailable, it must not create NaN, wrong array shape, fake zero targets, or misleading fitted output files.
+
+## 15. Backward Compatibility Plan
+
+- The current all-three global workflow should continue to work unchanged when `ms` contains blank-Psite protein rows and nonblank-Psite phospho rows and `rna` contains RNA rows.
+- Current config files should still run. No new mandatory config keys should be introduced.
+- The existing `[networkmodel].phospho` key should be used if future separate phospho input support is needed; if absent, default to `ms` as `config_loader.load_config_toml()` already does.
+- Existing all-three output file names should be preserved in all-three mode:
+  - `pred_prot_picked.csv`
+  - `pred_rna_picked.csv`
+  - `pred_phospho_picked.csv`
+  - `picked_objectives.json`
+  - `pareto_F.csv`
+  - `pareto_front.xlsx`
+  - existing plots and dashboard bundle.
+- Function signatures should be preserved where possible by adding optional `data_mode=None`/`active_layers=None` parameters with default behavior equivalent to all-three mode.
+- Internal changes may introduce data containers and mode metadata, but users should still configure `ms`, `rna`, `phospho`, timepoints, lambdas, scaling, and weighting the same way.
+- Inactive layers should not affect optimization or scalar solution selection.
+- Legacy/local workflow should not be changed in the first global implementation unless explicitly requested; if changed later, preserve old all-three behavior and fixed output sheets for all-three mode.
+
+## 16. Files That Will Likely Need Future Modification
+
+| File | Current role | Why it needs modification | Type of future change | Risk level | Notes |
+|---|---|---|---|---|---|
+| `networkmodel/io.py` | Loads networks and RNA/MS observations; splits MS into protein/phospho. | Needs raw layer detection, optional separate phospho file use, clearer validation, row-count metadata. | Add internal data-layer parsing/detection helpers; preserve return compatibility or return a data bundle. | High | Current `args.phospho` is not used for data loading. |
+| `networkmodel/runner.py` | Orchestrates global pipeline. | Needs effective mode finalization after filtering, active objective names, mode-aware optimizer calls, selection, plotting, saving, logging. | Add `DataMode` construction/use; condition downstream calls. | High | Most assumptions converge here. |
+| `networkmodel/cache.py` | Pre-indexes observations for loss. | Needs true zero counts, layer masks, safe empty arrays, validation. | Add `fit_layers`/`data_mode`, remove fake `max(1, len(...))` counts. | High | Critical for avoiding fake objectives. |
+| `networkmodel/optproblem.py` | Pymoo objective with fixed 3 objectives. | Needs dynamic objective count and objective-name mapping. | Add active-layer objective assembly. | High | Affects optimizer behavior and Pareto output shapes. |
+| `networkmodel/lossfn.py` | Low-level loss kernels. | May need masks or wrappers to skip unavailable layers cleanly. | Prefer keep kernels and change caller; add tests for empty arrays. | Medium | Numba changes are riskier; minimize edits. |
+| `networkmodel/simulate.py` | Extracts predicted RNA/protein/phospho tables. | Needs optional active-layer extraction and shared observable definitions. | Add `layers` parameter or structured return. | Medium | Preserve all-layer default for compatibility. |
+| `networkmodel/optuna_solver.py` | Alternative optimizer. | Needs alignment with mode-aware loss data and fold-change observables. | Refactor objective to use same loss arrays/objective assembly as Pymoo. | High | Current keys appear inconsistent with `prepare_fast_loss_data()`. |
+| `networkmodel/export.py` | Saves Pareto data, results, plots, residuals, S-rates. | Many functions assume three objectives/layers. | Add `data_mode`/objective names; skip inactive layers; dynamic sheets/plots. | High | Keep all-three output compatibility. |
+| `networkmodel/dashboard_bundle.py` | Saves dashboard pickle. | Should include mode metadata and active objective names. | Add metadata fields. | Medium | Backward compatible if new keys are optional. |
+| `networkmodel/dashboard_app.py` | Displays saved outputs. | Should hide unavailable layers and handle dynamic objectives. | Conditional UI rendering. | Medium | Only if dashboard is part of release. |
+| `networkmodel/scan.py` | Hyperparameter scan over lambdas/objectives. | Assumes protein/RNA/phospho lambdas and score components. | Dynamic active-layer lambdas and scoring. | Medium | Can initially disable scan for non-all modes with warning. |
+| `networkmodel/refine.py` | Refines Pymoo results. | May assume scalarization over fixed F columns. | Ensure dynamic objective arrays work. | Medium | Most logic may work if `problem.n_obj` is dynamic. |
+| `networkmodel/utils.py` | Column normalization, scaling, bounds. | Needs stronger validation helpers and possibly mode-aware bound fallback. | Add validation utilities; avoid changing scaling semantics. | Medium | Useful shared location for validators. |
+| `networkmodel/steadystate.py` | Builds y0 from data. | Needs explicit behavior when protein/RNA/phospho layers are absent. | Add logging/default-source metadata; validate missing data. | Medium | Current defaults may be acceptable but should be transparent. |
+| `config_loader.py` | Loads config into `PhosKinConfig`. | Existing schema can be preserved, but ambiguity around `phospho` default should be documented/possibly represented. | Maybe no code change; if changed, only internal default handling. | Low | Do not add mandatory config fields. |
+| `networkmodel/config.py` | Exposes config constants. | May need to expose/use `WEIGHTING_METHOD_PHOSPHO` correctly. | Ensure existing value is imported and consumed. | Low | Schema already has the field. |
+| `protwise/runner/main.py` | Legacy/local runner. | If local workflow is included later, it must stop requiring mRNA/phospho intersection for all modes. | Add local mode detection and per-gene layer availability. | High | Defer until global support is stable. |
+| `protwise/paramest/core.py` | Extracts per-gene arrays and metrics. | Fixed all-layer extraction/metrics. | Structured layer data and mode-aware metrics. | High | Defer if scope is global model first. |
+| `protwise/paramest/normest.py` | Local curve-fit target construction. | Fixed concatenated `[mRNA, protein, phospho]` target. | Dynamic target/model-output concatenation. | High | Shape bugs likely. |
+| `protwise/models/*.py` | Local ODE solvers and flattening. | Fixed output vector order/length. | Add structured observables or active-layer flattening. | Medium | Core ODE can stay unchanged. |
+| `protwise/plotting/plotting.py` | Local plots. | Fixed mRNA/protein/phospho panels and slice lengths. | Mode-aware plotting. | Medium | Defer if local not targeted. |
+| `common/utils/display.py` | Local saving/report merging. | Phosphosite-centric observed/estimated merging; fixed sheets. | Mode-aware sheets and report merge. | Medium | Defer if local not targeted. |
+| `docs/Documentation/configuration.md`, `docs/Documentation/architecture.md`, `README.md` | Documentation. | Must explain supported data modes after implementation. | Documentation update only after code changes. | Low | Do not alter schema docs prematurely. |
+| `tests/` | Existing tests. | Need coverage for seven modes. | Add fixtures/unit/integration tests. | Medium | Do not modify in this audit. |
+
+## 17. Files That Should Probably Not Be Modified
+
+| File | Reason to avoid modifying | Risk if changed |
+|---|---|---|
+| `networkmodel/models.py` | Core RHS kernels already support the structural states needed for all modes. Mode-specific logic should live in observables/loss, not RHS. | High risk of changing model behavior or numerical stability. |
+| `networkmodel/solvers.py`, `networkmodel/model_ivp.py`, `networkmodel/jacspeedup.py` | Solver mechanics should not need data-mode awareness. | High risk of numerical regressions. |
+| `networkmodel/buildmat.py` | Matrix construction is topology-driven, not observation-mode-driven. | Medium/high risk of changing model topology. |
+| `networkmodel/params.py` | Parameter vector should remain structurally consistent across modes. | High risk of breaking optimizer/export compatibility. |
+| `config.toml` | User explicitly requires no schema/config changes. | High risk of breaking existing users and violating requirement. |
+| `config/cli.py` | Existing CLI/config interface should remain stable. | Medium risk of user-facing API drift. |
+| `config/logconf.py` | Logging infrastructure is adequate; only messages need updates. | Low/medium risk of test breakage or duplicate handlers. |
+| `tests/test_config.py` | Existing logging tests are unrelated. | Low risk, but do not touch during feature implementation unless logging setup changes. |
+| `processing/cleanup.py`, `processing/map.py` | Preprocessing can remain an upstream source of current files. | Medium risk of altering data-generation behavior. |
+| `scripts/*` | Standalone post-processing should not block core support. | Medium risk of broad unrelated changes. |
+| `docs/assets/*` | Static assets unrelated to multimodal input support. | Low value, unnecessary churn. |
+| `common/frechet/distance.py` | Distance metric can be reused; mode filtering should happen before calls. | Low/medium risk of metric regression. |
+
+## 18. Proposed Implementation Phases for a Later Agent
+
+### Phase 1: Add internal data-layer detection
+
+Expected files:
+
+- `networkmodel/io.py`
+- `networkmodel/runner.py`
+- possibly a new internal module such as `networkmodel/datamode.py`
+
+Checks:
+
+- Unit-test raw detection for mixed `ms`, separate `phospho`, RNA-only, protein-only, phospho-only, and empty files.
+- Verify no config schema change.
+- Verify all-three current config detects all layers.
+
+### Phase 2: Normalize data containers
+
+Expected files:
+
+- `networkmodel/io.py`
+- `networkmodel/utils.py`
+- `networkmodel/runner.py`
+
+Checks:
+
+- Each layer returns a data frame with canonical columns.
+- Identifier normalization is consistent.
+- Raw and filtered counts are preserved in metadata.
+- Separate phospho file uses appropriate time grid or documented fallback.
+
+### Phase 3: Refactor model output interface
+
+Expected files:
+
+- `networkmodel/simulate.py`
+- possibly `networkmodel/export.py`
+
+Checks:
+
+- `simulate_and_measure()` all-layer default matches current output in all-three mode.
+- Active-layer extraction returns only requested layer data frames.
+- Combinatorial and non-combinatorial observable extraction both pass shape checks.
+
+### Phase 4: Dynamic loss construction
+
+Expected files:
+
+- `networkmodel/cache.py`
+- `networkmodel/optproblem.py`
+- `networkmodel/lossfn.py` only if necessary
+
+Checks:
+
+- Empty unavailable layers produce no objective contribution.
+- No fake zeros, NaNs, or fake counts.
+- Active-layer objective names and counts are correct for all seven modes.
+- All-three mode matches current loss values within tolerance.
+
+### Phase 5: Mode-aware optimization
+
+Expected files:
+
+- `networkmodel/runner.py`
+- `networkmodel/optproblem.py`
+- `networkmodel/optuna_solver.py`
+- `networkmodel/refine.py`
+- `networkmodel/scan.py`
+
+Checks:
+
+- Pymoo runs with one, two, and three objectives.
+- Reference directions are valid for active objective count.
+- Solution selection uses only active layers.
+- Optuna is either fixed for mode-aware support or clearly disabled with a warning for unsupported modes until fixed.
+
+### Phase 6: Mode-aware plotting
+
+Expected files:
+
+- `networkmodel/export.py`
+- `networkmodel/dashboard_app.py` if dashboard support is included
+
+Checks:
+
+- Goodness-of-fit plots generate for each of seven modes.
+- Time-series plots create only active fitted panels.
+- 3D Pareto plot is skipped or replaced for one/two objective modes.
+- All-three plots remain compatible.
+
+### Phase 7: Mode-aware saving/reporting
+
+Expected files:
+
+- `networkmodel/runner.py`
+- `networkmodel/export.py`
+- `networkmodel/dashboard_bundle.py`
+
+Checks:
+
+- Prediction files are written only for fitted layers.
+- `data_mode.json` is saved.
+- Pareto CSV/Excel have correct dynamic columns and compatibility metadata.
+- No output path breaks in all-three mode.
+
+### Phase 8: Logging and validation
+
+Expected files:
+
+- `networkmodel/io.py`
+- `networkmodel/runner.py`
+- `networkmodel/utils.py`
+- `networkmodel/steadystate.py`
+
+Checks:
+
+- Logs include detected mode, active/skipped layers, shapes, losses, and outputs.
+- Invalid/malformed inputs fail with explicit messages.
+- Missing optional layers are warnings, not crashes, when at least one valid layer remains.
+
+### Phase 9: Tests
+
+Expected files:
+
+- New tests under `tests/`, likely `tests/test_networkmodel_datamode.py`, `tests/test_networkmodel_loss_modes.py`, and `tests/test_networkmodel_outputs_modes.py`.
+
+Checks:
+
+- Unit tests for all seven data modes.
+- Regression test for all-three current behavior.
+- Invalid input tests.
+- Plot/output smoke tests with small fixtures.
+
+### Phase 10: Documentation update
+
+Expected files:
+
+- `README.md`
+- `docs/Documentation/configuration.md`
+- `docs/Documentation/architecture.md`
+- `networkmodel/README.md`
+
+Checks:
+
+- Docs state that config schema is unchanged.
+- Docs explain layer inference rules and output differences by mode.
+- Docs clearly distinguish fitted outputs from optional diagnostic simulations.
+
+## 19. Test Plan for Later Implementation
+
+### Unit tests
+
+- `detect_data_mode()` returns the correct mode for each of the seven combinations.
+- Detection distinguishes raw availability from effective availability after filtering.
+- Mixed `ms` file splits blank `Psite` rows as protein and nonblank `Psite` rows as phospho.
+- Separate `phospho` path is used when provided and distinct from `ms`.
+- Missing layer files are handled as optional when other layers exist.
+- Malformed present files produce clear layer-specific errors.
+- `prepare_fast_loss_data()` returns true zero counts for absent layers and valid arrays for present layers.
+- Objective-name mapping is correct for all modes.
+
+### Loss tests
+
+For a tiny synthetic `Index`/`System` and deterministic `Y`:
+
+- mRNA-only objective includes only RNA residuals.
+- protein-only objective includes only protein residuals.
+- phospho-only objective includes only phospho residuals.
+- Combined modes include exactly the expected residual sums.
+- Empty inactive arrays do not affect objective values.
+- No loss path returns NaN/inf for missing layers.
+- All-three mode reproduces previous three-loss behavior.
+
+### Optimization smoke tests
+
+- Pymoo problem can be constructed for one, two, and three objectives.
+- Reference directions/algorithm setup works for active objective counts or uses appropriate single-objective/two-objective alternatives.
+- A very small optimization run completes for each mode with tiny fixtures.
+- Solution selection computes scalar/Fréchet scores using only active layers.
+
+### Output tests
+
+For each mode:
+
+- Correct picked prediction files exist for fitted layers.
+- Prediction files for skipped layers do not exist or are clearly diagnostic-only.
+- `data_mode.json` exists and matches mode.
+- `picked_objectives.json` has active objective values and no misleading inactive values.
+- Pareto CSV/Excel objective columns match active layers.
+- Goodness-of-fit plots are generated for active layers only.
+- Dashboard bundle contains mode metadata.
+
+### Backward compatibility tests
+
+- Existing all-three fixture/config produces the same output file names as before.
+- Old config with `phospho` missing or equal to `ms` still works.
+- Existing lambdas and weighting settings remain accepted.
+- Existing logging tests still pass.
+
+### Invalid/malformed input tests
+
+- No active layers after filtering -> explicit error before optimization.
+- Missing required identifier column in a present RNA file -> explicit RNA parse error.
+- Missing `Psite` column in an explicit phospho file -> explicit phospho parse error.
+- Inconsistent time columns not in configured grid -> explicit time-grid error.
+- Duplicate observations -> deterministic deduplication warning or error.
+- Phosphosite rows absent from kinase network -> logged filtered count and skipped layer if none remain.
+- Protein/RNA identifiers incompatible with model index -> warning and failure if no active rows remain.
+
+## 20. Risks and Failure Modes
+
+- Silent layer misclassification, especially when `Psite` is missing, blank, string `nan`, or present in separate phospho files.
+- Existing `[networkmodel].phospho` key is currently ambiguous because it defaults to `ms` and is not used by `load_data()`.
+- Wrong observable matched to the wrong data layer, especially protein total vs unphosphorylated protein or phosphosite state vs total phosphoprotein signal.
+- Shape mismatch between flattened targets and predictions in the legacy/local workflow.
+- NaNs or fake zeros introduced for missing layers.
+- Dynamic objective count breaking Pymoo reference directions, Pareto plotting, Excel export, dashboard display, or hyperparameter scan.
+- Inactive objective constants distorting Pareto selection if a fixed three-objective design is used incorrectly.
+- Overfitting or unstable unconstrained states when fitting sparse layers, e.g. phospho-only without protein/RNA constraints.
+- Broken existing all-three/phospho-heavy workflow due to changed file splitting or filtering.
+- Data-derived initial conditions using misleading defaults without logging when layers are absent.
+- Broken plotting assumptions in fixed three-panel plots and fixed 3D Pareto plots.
+- Broken saving assumptions in `picked_objectives.json`, `pareto_F.csv`, `pareto_front.xlsx`, and dashboard bundles.
+- Logger not reporting skipped layers, causing users to believe unavailable layers were fitted.
+- Downstream scripts expecting old output files for every layer.
+- Separate global and legacy/local workflows diverging in mode semantics if both are changed independently.
+- Optuna path using different loss-index mechanics than Pymoo path and becoming inconsistent.
+
+## 21. Final Recommendation
+
+Implement multimodal input support first in the global `networkmodel` workflow, not the legacy/local `protwise` workflow. The global workflow already separates observations into `df_rna`, `df_prot`, and `df_pho`, has model states for all three layers, and has separate low-level loss sums. The safest strategy is:
+
+1. Add an internal `DataMode`/`available_layers` object with no config schema changes.
+2. Detect raw layer availability in `networkmodel.io.load_data()` and finalize effective fit mode in `networkmodel.runner.main()` after filtering.
+3. Preserve the same model structure and parameter vector.
+4. Make loss/objective assembly dynamic over active layers.
+5. Make plotting, saving, solution selection, and dashboard metadata consume the same `DataMode` object.
+6. Preserve all existing file names and semantics for the current all-three mode.
+7. Add exhaustive tests for all seven modes before changing documentation.
+
+Avoid modifying RHS kernels, solvers, user-facing config, or KinOpt/TFOpt. Treat missing layers as unavailable observations, not as zero-valued data. Every skipped layer should be visible in logs and output metadata.


### PR DESCRIPTION
### Motivation

- Provide a single audit/planning document that maps the current PhosKinTime codebase to a safe, testable plan for adding concurrent mRNA/protein/phospho input support without changing the public configuration schema. 
- Capture current assumptions, data flow, observable extraction, loss construction, optimization, plotting, saving, and logging so the same core ODE model can be used across seven valid data-mode combinations while avoiding regressions. 

### Description

- Added a documentation-only planning file at `docs/phoskintime_multimodal_input_audit.md` that inspects the repository (excluding KinOpt and TFOpt) and summarizes relevant modules such as `networkmodel/runner.py`, `networkmodel/io.py`, `networkmodel/cache.py`, `networkmodel/lossfn.py`, `networkmodel/optproblem.py`, `networkmodel/simulate.py`, `networkmodel/export.py`, and the legacy `protwise/` workflow. 
- The document traces current data flow (config loading → input parsing → preprocessing → model setup → ODE solving → loss construction → optimization → result extraction → plotting/saving/reporting) and records exact functions and files involved. 
- It enumerates the seven desired modes (mRNA only, protein only, phospho only, mRNA+protein, mRNA+phospho, protein+phospho, mRNA+protein+phospho) and specifies per-mode effects on validation, observable extraction, loss assembly, optimization, plotting, saving, reporting, and logging. 
- The audit proposes an internal `DataMode` metadata object and a two-stage detection strategy (raw detection in `networkmodel.io.load_data()` and effective-mode finalization in `networkmodel.runner.main()`), recommends a structured model-observable interface, and gives concrete guidance for dynamic loss/objective assembly and optimizer integration while preserving backward compatibility. 
- It lists files likely to need changes (with risk levels), files to avoid modifying, a phased implementation plan (10 phases), a detailed test plan covering all seven modes, validation rules, and a risk/failure-mode catalogue, finishing with a concise recommendation to implement changes first in the `networkmodel` pipeline. 

### Testing

- This is a documentation-only change so no automated tests were modified or executed against the codebase, and the existing test suite remains unchanged. 
- The new file was added and manually inspected in the repository to ensure it references relevant modules and functions; no code or config files were altered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e4b0d5c0c8327be693b8316ed4a2c)