### PR TITLE
Fix global networkmodel phospho objective mapping

### DIFF
--- a/networkmodel/cache.py
+++ b/networkmodel/cache.py
@@ -148,13 +148,18 @@ def prepare_fast_loss_data(idx, df_prot, df_rna, df_pho, time_grid):
     p_pho, s_pho, t_pho, obs_pho, w_pho = _empty_phospho() if df_pho is None or df_pho.empty else get_indices_phospho(
         df_pho)
 
-    # prot_map: A lookup table for the loss function to know where a protein's data starts in Y.
-    # Structure: [Start Index in Y, Count (sites or states)]
+    # prot_map: A lookup table for the global JAX loss to know where each
+    # protein's block starts in the flattened ODE state vector. The global
+    # networkmodel state layout is:
+    #   MODEL 0/1: [mRNA, unphosphorylated protein, phospho_site_0, ...]
+    #   MODEL 2:   [mRNA, combinatorial protein_state_0, ... protein_state_(2^n-1)]
+    # The second column is therefore n_sites for MODEL 0/1 and n_states for
+    # MODEL 2. n_sites is also exported separately so MODEL 2 phospho rows can
+    # aggregate states with the requested site bit set.
     prot_map = np.zeros((idx.N, 2), dtype=np.int32)
     for i in range(idx.N):
         sl = idx.block(i)
         prot_map[i, 0] = sl.start
-        # If MODEL==2, the state vector structure might differ, requiring total states vs just site count.
         prot_map[i, 1] = int(idx.n_states[i]) if MODEL == 2 else int(idx.n_sites[i])
 
     return {
@@ -162,6 +167,9 @@ def prepare_fast_loss_data(idx, df_prot, df_rna, df_pho, time_grid):
         "p_rna": p_rna, "t_rna": t_rna, "obs_rna": obs_rna, "w_rna": w_rna,
         "p_pho": p_pho, "s_pho": s_pho, "t_pho": t_pho, "obs_pho": obs_pho, "w_pho": w_pho,
         "prot_map": np.ascontiguousarray(prot_map, dtype=np.int32),
+        "n_sites": np.ascontiguousarray(idx.n_sites, dtype=np.int32),
+        "state_layout": "combinatorial" if MODEL == 2 else "standard",
+        "backend_mode": "networkmodel",
         "n_p": len(obs_prot),
         "n_r": len(obs_rna),
         "n_ph": len(obs_pho),

--- a/networkmodel/export.py
+++ b/networkmodel/export.py
@@ -193,11 +193,12 @@ def export_pareto_front_to_excel(
 
     # ---- Summary + ranking ----
     F = np.asarray(F)
-    if F.ndim == 1 or F.shape[1] == 1:
-        # New JAX scalar objective: F contains a single value per solution
+    if F.ndim == 1 or (F.ndim == 2 and F.shape[1] == 1):
+        # New global JAX scalar objective: F contains a single scalar score per
+        # solution. Do not create legacy prot_mse/rna_mse/phospho_mse columns.
         scalar_vals = F.reshape(-1)
         df_summary = pd.DataFrame({"scalar_score": scalar_vals})
-    else:
+    elif F.ndim == 2 and F.shape[1] == 3:
         # Legacy 3-objective table
         df_summary = pd.DataFrame(F, columns=["prot_mse", "rna_mse", "phospho_mse"])
         # derive scalar_score from weighted sum
@@ -206,6 +207,8 @@ def export_pareto_front_to_excel(
                 + w_rna * df_summary["rna_mse"]
                 + w_phos * df_summary["phospho_mse"]
         )
+    else:
+        raise ValueError(f"Expected scalar F with shape (n,) or (n, 1), or legacy F with shape (n, 3). Got {F.shape}.")
 
     df_summary.insert(0, "sol_id", np.arange(len(df_summary), dtype=int))
     df_summary["w_prot"] = w_prot

--- a/networkmodel/jax_backend.py
+++ b/networkmodel/jax_backend.py
@@ -186,19 +186,85 @@ def _extract_offsets(prot_map):
     return pm[:, 0], pm[:, 1]
 
 
-def multimodal_loss_from_trajectory(Y, loss_data: Mapping, mode: DataMode, weights: Mapping[str, float] | None = None):
+def _safe_fold_change(values, base_values):
+    return jnp.maximum(values, 1e-12) / jnp.maximum(base_values, 1e-12)
+
+
+def _global_networkmodel_observable(Y, offsets, counts, n_sites, protein_idx, time_idx, *, layer, site_idx=None,
+                                    base_idx=0, layout="standard", max_count=1):
+    """Map global networkmodel state trajectories to fitted fold-change observables.
+
+    Global state layout assumptions are deliberately kept in this networkmodel-only
+    helper so protwise callers retain the legacy direct-state indexing path:
+      * standard/sequential: [mRNA, unphosphorylated protein, phospho_site_0, ...]
+      * combinatorial:       [mRNA, protein_state_0, ..., protein_state_(2^n-1)]
+    Protein observations are total protein fold changes. Phospho observations are
+    site fold changes: direct site states for standard layouts and bitwise sums of
+    combinatorial protein states for MODEL==2 layouts.
+    """
+    off = offsets[protein_idx]
+    count = counts[protein_idx]
+    t = time_idx
+    b = jnp.asarray(base_idx, dtype=jnp.int32)
+
+    if layer == "mrna":
+        return _safe_fold_change(Y[t, off], Y[b, off])
+
+    if layout == "combinatorial":
+        ar = jnp.arange(max_count, dtype=jnp.int32)
+        valid_state = ar < count
+        state_positions = jnp.minimum(off + 1 + ar, Y.shape[1] - 1)
+        states_t = jnp.where(valid_state, Y[t, state_positions], 0.0)
+        states_b = jnp.where(valid_state, Y[b, state_positions], 0.0)
+        if layer == "protein":
+            return _safe_fold_change(jnp.sum(states_t), jnp.sum(states_b))
+        site = jnp.asarray(0 if site_idx is None else site_idx, dtype=jnp.int32)
+        valid_site = site < n_sites[protein_idx]
+        bit_mask = jnp.where(valid_state, ((ar >> site) & 1).astype(jnp.float64), 0.0)
+        pho_t = jnp.sum(states_t * bit_mask)
+        pho_b = jnp.sum(states_b * bit_mask)
+        return jnp.where(valid_site, _safe_fold_change(pho_t, pho_b), 0.0)
+
+    # Standard/sequential global layout: mRNA at offset, unphosphorylated protein
+    # at offset+1, and local phospho site s at offset+2+s.
+    if layer == "protein":
+        ar = jnp.arange(max_count + 1, dtype=jnp.int32)
+        valid_state = ar < (count + 1)
+        positions = jnp.minimum(off + 1 + ar, Y.shape[1] - 1)
+        total_t = jnp.sum(jnp.where(valid_state, Y[t, positions], 0.0))
+        total_b = jnp.sum(jnp.where(valid_state, Y[b, positions], 0.0))
+        return _safe_fold_change(total_t, total_b)
+
+    site = jnp.asarray(0 if site_idx is None else site_idx, dtype=jnp.int32)
+    pred = Y[t, off + 2 + site]
+    base = Y[b, off + 2 + site]
+    return _safe_fold_change(pred, base)
+
+
+def multimodal_loss_from_trajectory(Y, loss_data: Mapping, mode: DataMode, weights: Mapping[str, float] | None = None,
+                                    *, networkmodel_layout: bool = False):
     weights = weights or {}
     prot_map = jnp.asarray(loss_data["prot_map"], dtype=jnp.int32)
     offsets, counts = _extract_offsets(prot_map)
     total = jnp.asarray(0.0, dtype=jnp.float64)
     breakdown = {}
+    layout = str(loss_data.get("state_layout", "standard"))
+    n_sites = jnp.asarray(loss_data.get("n_sites", counts), dtype=jnp.int32)
+    max_count = int(np.max(np.asarray(loss_data["prot_map"], dtype=np.int32)[:, 1])) if len(loss_data["prot_map"]) else 1
 
     if mode.fit_protein:
         p = jnp.asarray(loss_data["p_prot"], dtype=jnp.int32)
         t = jnp.asarray(loss_data["t_prot"], dtype=jnp.int32)
         obs = jnp.asarray(loss_data["obs_prot"], dtype=jnp.float64)
         w = jnp.asarray(loss_data["w_prot"], dtype=jnp.float64)
-        pred = Y[t, offsets[p] + 1]
+        if networkmodel_layout:
+            base_idx = int(loss_data.get("prot_base_idx", 0))
+            pred = jax.vmap(lambda pi, ti: _global_networkmodel_observable(
+                Y, offsets, counts, n_sites, pi, ti, layer="protein", base_idx=base_idx, layout=layout,
+                max_count=max_count
+            ))(p, t)
+        else:
+            pred = Y[t, offsets[p] + 1]
         loss = jnp.sum(w * (pred - obs) ** 2) / jnp.maximum(jnp.sum(w), 1.0)
         total = total + float(weights.get("protein", 1.0)) * loss
         breakdown["protein"] = loss
@@ -207,7 +273,14 @@ def multimodal_loss_from_trajectory(Y, loss_data: Mapping, mode: DataMode, weigh
         t = jnp.asarray(loss_data["t_rna"], dtype=jnp.int32)
         obs = jnp.asarray(loss_data["obs_rna"], dtype=jnp.float64)
         w = jnp.asarray(loss_data["w_rna"], dtype=jnp.float64)
-        pred = Y[t, offsets[p]]
+        if networkmodel_layout:
+            base_idx = int(loss_data.get("rna_base_idx", 0))
+            pred = jax.vmap(lambda pi, ti: _global_networkmodel_observable(
+                Y, offsets, counts, n_sites, pi, ti, layer="mrna", base_idx=base_idx, layout=layout,
+                max_count=max_count
+            ))(p, t)
+        else:
+            pred = Y[t, offsets[p]]
         loss = jnp.sum(w * (pred - obs) ** 2) / jnp.maximum(jnp.sum(w), 1.0)
         total = total + float(weights.get("mrna", weights.get("rna", 1.0))) * loss
         breakdown["mrna"] = loss
@@ -217,7 +290,14 @@ def multimodal_loss_from_trajectory(Y, loss_data: Mapping, mode: DataMode, weigh
         t = jnp.asarray(loss_data["t_pho"], dtype=jnp.int32)
         obs = jnp.asarray(loss_data["obs_pho"], dtype=jnp.float64)
         w = jnp.asarray(loss_data["w_pho"], dtype=jnp.float64)
-        pred = Y[t, offsets[p] + 2 + s]
+        if networkmodel_layout:
+            base_idx = int(loss_data.get("pho_base_idx", 0))
+            pred = jax.vmap(lambda pi, si, ti: _global_networkmodel_observable(
+                Y, offsets, counts, n_sites, pi, ti, layer="phospho", site_idx=si, base_idx=base_idx, layout=layout,
+                max_count=max_count
+            ))(p, s, t)
+        else:
+            pred = Y[t, offsets[p] + 2 + s]
         loss = jnp.sum(w * (pred - obs) ** 2) / jnp.maximum(jnp.sum(w), 1.0)
         total = total + float(weights.get("phospho", 1.0)) * loss
         breakdown["phospho"] = loss
@@ -335,22 +415,35 @@ def optimize_scalar_objective(objective_fun, theta0, lower, upper, *, maxiter=20
 
 
 def make_simple_objective(loss_data: Mapping, mode: DataMode, time_grid: Sequence[float], weights=None, defaults=None,
-                          prior_weight=0.0):
+                          prior_weight=0.0, *, networkmodel_layout: bool = False, return_breakdown: bool = False,
+                          y0=None):
     validate_loss_data(loss_data, mode)
     t = jnp.asarray(time_grid, dtype=jnp.float64)
     prot_map = np.asarray(loss_data["prot_map"])
-    state_dim = int(np.max(prot_map[:, 0] + np.maximum(prot_map[:, 1] + 2, 2))) if len(prot_map) else 2
-    y0 = jnp.ones(state_dim, dtype=jnp.float64)
+    if len(prot_map):
+        layout = str(loss_data.get("state_layout", "standard"))
+        state_width = prot_map[:, 1] + (1 if layout == "combinatorial" else 2)
+        state_dim = int(np.max(prot_map[:, 0] + np.maximum(state_width, 2)))
+    else:
+        state_dim = 2
+    y0 = jnp.ones(state_dim, dtype=jnp.float64) if y0 is None else jnp.asarray(y0, dtype=jnp.float64)
     defaults_j = None if defaults is None else jnp.asarray(defaults, dtype=jnp.float64)
 
     def objective(theta):
         theta = jnp.asarray(theta, dtype=jnp.float64)
         rates = jax.nn.softplus(theta)
         Y = solve_diffrax(y0, t, params=rates)
-        total, _ = multimodal_loss_from_trajectory(Y, loss_data, mode, weights=weights)
+        total, breakdown = multimodal_loss_from_trajectory(
+            Y, loss_data, mode, weights=weights, networkmodel_layout=networkmodel_layout
+        )
         if defaults_j is not None and prior_weight:
             d = rates[: defaults_j.size] - defaults_j
-            total = total + float(prior_weight) * jnp.mean(d * d)
+            prior = float(prior_weight) * jnp.mean(d * d)
+            total = total + prior
+            breakdown["prior"] = prior
+        if return_breakdown:
+            breakdown["scalar_total"] = jnp.asarray(total, dtype=jnp.float64)
+            return jnp.asarray(total, dtype=jnp.float64), breakdown
         return jnp.asarray(total, dtype=jnp.float64)
 
     return objective

--- a/networkmodel/optproblem.py
+++ b/networkmodel/optproblem.py
@@ -43,14 +43,35 @@ class GlobalODEScalarObjective:
         validate_loss_data(loss_data, self.data_mode)
         logger.info("[Objective] Single scalar objective initialized for mode %s", self.data_mode.data_mode)
         logger.info("[Objective] Parameter vector size: %d", self.n_var)
+        # Global networkmodel scalar objective combines weighted modality MSEs on
+        # fold-change observables. The networkmodel_layout flag keeps the global
+        # state-to-observation mapping separate from protwise's shared-backend path.
+        objective_weights = {
+            "protein": self.lambdas.get("protein", 1.0),
+            "rna": self.lambdas.get("rna", 1.0),
+            "phospho": self.lambdas.get("phospho", 1.0),
+        }
+        y0 = sys.y0() if hasattr(sys, "y0") else None
         self._objective = make_simple_objective(
             loss_data,
             self.data_mode,
             self.time_grid,
-            weights={"protein": self.lambdas.get("protein", 1.0), "rna": self.lambdas.get("rna", 1.0),
-                     "phospho": self.lambdas.get("phospho", 1.0)},
+            weights=objective_weights,
             prior_weight=float(self.lambdas.get("prior", 0.0)),
+            networkmodel_layout=True,
+            y0=y0,
         )
+        self._objective_raw = make_simple_objective(
+            loss_data,
+            self.data_mode,
+            self.time_grid,
+            weights=objective_weights,
+            prior_weight=float(self.lambdas.get("prior", 0.0)),
+            networkmodel_layout=True,
+            return_breakdown=True,
+            y0=y0,
+        )
+        self.final_loss_breakdown = {}
 
     def objective(self, x):
         return self._objective(jnp.asarray(x, dtype=jnp.float64))
@@ -65,6 +86,14 @@ class GlobalODEScalarObjective:
     def solve(self, theta0, maxiter=50, tol=1e-6):
         params, state, value = optimize_scalar_objective(self.objective, theta0, self.xl, self.xu, maxiter=maxiter,
                                                          tol=tol, logger_obj=logger)
+        raw_val, breakdown = self._objective_raw(jnp.asarray(params, dtype=jnp.float64))
+        self.final_loss_breakdown = {k: float(v) for k, v in breakdown.items()}
+        logger.info("[GlobalObjective] Final per-modality loss: %s", self.final_loss_breakdown)
+        if "phospho" not in self.final_loss_breakdown and self.data_mode.fit_phospho:
+            logger.warning("[GlobalObjective] Phospho data were detected but no phospho loss was reported.")
+        if np.isfinite(float(raw_val)) and abs(float(raw_val) - float(value)) > max(1e-6, 1e-6 * abs(float(value))):
+            logger.warning("[GlobalObjective] Raw objective %.8g differs from optimizer value %.8g.",
+                           float(raw_val), float(value))
         return params, state, value
 
 

--- a/networkmodel/runner.py
+++ b/networkmodel/runner.py
@@ -535,6 +535,14 @@ def main():
     loss_data["prot_base_idx"] = _base_idx(solver_times, 0.0)
     loss_data["rna_base_idx"] = _base_idx(solver_times, 4.0)
     loss_data["pho_base_idx"] = _base_idx(solver_times, 0.0)
+    logger.info(
+        "[GlobalObjective] Loss data mapped with %s state layout; phospho rows=%d; lambda_phospho=%g",
+        loss_data.get("state_layout", "standard"),
+        int(loss_data.get("n_ph", 0)),
+        float(args.lambda_phospho),
+    )
+    if float(args.lambda_phospho) == 0.0 and int(loss_data.get("n_ph", 0)) > 0:
+        logger.warning("[GlobalObjective] Phospho data are present but --lambda-phospho is zero.")
 
     # 6) Decision vector bounds
 
@@ -623,7 +631,7 @@ def main():
         params=np.asarray(best_x, dtype=float),
         state=opt_state,
         data_mode=mode,
-        loss_breakdown={},
+        loss_breakdown=dict(problem.final_loss_breakdown),
     )
     # Save full result object
     with open(os.path.join(args.output_dir, f"{args.solver}_optimization_result.pkl"), "wb") as f:
@@ -822,15 +830,15 @@ def main():
     with open(os.path.join(args.output_dir, "fitted_params_picked.json"), "w") as f:
         json.dump(p_out, f, indent=2)
 
-    # Write picked objective values
-    picked = {"prot_mse": float(F[I, 0]), "rna_mse": float(F[I, 1]), "phospho_mse": float(F[I, 2]),
-              "scalar_score": float(
-                  args.lambda_protein * F[I, 0] + args.lambda_rna * F[I, 1] + args.lambda_phospho * F[I, 2])}
+    # Write picked objective values. Global JAXopt now returns a scalar F with
+    # per-modality components captured from the scalar objective breakdown.
+    scalar_score = float(np.asarray(F[I]).reshape(-1)[0])
+    picked = {"scalar_score": scalar_score}
+    picked.update({k: float(v) for k, v in getattr(res, "loss_breakdown", {}).items()})
     with open(os.path.join(args.output_dir, "picked_objectives.json"), "w") as f:
         json.dump(picked, f, indent=2)
 
-    logger.info(
-        f"[Loss] Solution: prot_mse={picked['prot_mse']:.6f}, rna_mse={picked['rna_mse']:.6f}, phospho_mse={picked['phospho_mse']:.6f}, scalar_score={picked['scalar_score']:.6f}")
+    logger.info("[Loss] Picked scalar objective breakdown: %s", picked)
 
     plot_goodness_of_fit(df_prot, dfp, df_rna, dfr, df_pho, dfph, output_dir=args.output_dir)
     logger.info("[Done] Goodness of Fit plot saved.")


### PR DESCRIPTION
### Motivation
- The global networkmodel was comparing phospho observations against incorrect state-vector entries and using raw state values rather than fold-change observables, producing uniformly huge phospho errors that dominated the scalar objective.
- The protwise path is known-good and must remain unchanged, so global-specific mapping and loss composition must be introduced without altering protwise behavior.
- Provide visibility into per-modality losses at the scalar optimum to confirm whether phospho is included and correctly weighted.
- Quick manual check: run a short global fit (e.g. `pixi run networkmodel --n-gen 50 --lambda-protein 1 --lambda-rna 1 --lambda-phospho 1`) and expect phospho Fréchet distances to drop and vary across sites instead of staying uniformly large.

### Description
- Added a networkmodel-only observable mapper and fold-change helper in `networkmodel/jax_backend.py` so global runs compute predicted fold-change observables from the ODE state for both standard (distributive/sequential) and combinatorial (MODEL==2) layouts, and gated this behind `networkmodel_layout=True` so protwise callers keep the legacy indexing path.
- Reworked `multimodal_loss_from_trajectory` to optionally use the new global mapper (when `networkmodel_layout=True`) for protein, mrna, and phospho terms and to produce a `breakdown` dict of per-modality losses.
- Enhanced `make_simple_objective` to accept `networkmodel_layout`, `return_breakdown`, and `y0` so the global objective can request breakdowns and use system initial conditions without changing protwise behavior.
- In `networkmodel/optproblem.py` the global scalar objective now constructs the objective with `networkmodel_layout=True`, builds an `_objective_raw` that returns a breakdown, and logs/stores the final per-modality loss after `solve` (only for the global path).
- In `networkmodel/cache.py` `prepare_fast_loss_data` now emits `n_sites`, `state_layout`, and `backend_mode` (set to `networkmodel`) so the backend has the metadata needed to map phospho rows correctly (especially for combinatorial states).
- In `networkmodel/runner.py` added logging that reports the mapped `state_layout`, number of phospho rows, and `--lambda-phospho` value, carried the `final_loss_breakdown` into the saved `JaxoptResult`, and updated the picked-objectives JSON to record `scalar_score` plus the breakdown instead of assuming a 3-column F.
- In `networkmodel/export.py` made the summary sheet robust to the new scalar `F` shape (accept `F` as scalar `(n,)` or `(n,1)` and only emit `scalar_score`), and preserved legacy behavior for `(n,3)` multi-objective results.
- Kept all protwise callers unchanged; the new mapping is only activated for the global/networkmodel path via explicit flags and `loss_data` metadata.

### Testing
- Ran static checks: `git diff --check` (no whitespace errors) and code compilation: `python -m compileall -q networkmodel/jax_backend.py networkmodel/cache.py networkmodel/optproblem.py networkmodel/runner.py networkmodel/export.py`, both completed successfully.
- Verified the repository staged changes and committed the patch locally (commit message: "Fix global networkmodel phospho objective mapping").
- Attempted an automated quick-run smoke test with `pixi` but the container has no `pixi` binary, so end-to-end JAX/Diffrax optimization could not be executed here. Automated compile and lint checks passed.
- The change is gated so unit/protwise flows remain unchanged; the new global mapping will be exercised when running the global `networkmodel` runner which should be used to validate phospho Fréchet reductions on your CI or local environment with `pixi` or the project runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eb5f035cc8327a72eab2b380528dd)