### PR TITLE
Wire networkmodel inference config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -280,23 +280,23 @@ seed       = 42
 # ------------------------------------------------------------
 # OPTIMIZER SELECTION
 # ------------------------------------------------------------
-optimizer = "pymoo"          # Legacy value accepted; PhosKinTime global maps to jaxopt
+# removed: optimizer — legacy evolutionary/Optuna selector; networkmodel always uses JAXopt
 
 # ------------------------------------------------------------
 # OPTIMIZATION PARAMETERS (Optuna)
 # ------------------------------------------------------------
-study_name = "phoskintime_networkmodel_ABL2_jax"  # Optuna study name
-sampler    = "TPESampler"           # Optuna sampler: TPESampler, RandomSampler, CMAESampler
-pruner     = "MedianPruner"         # Optuna pruner: MedianPruner, NopPruner, SuccessiveHalvingPruner
-n_trials  = 1000                      # Number of Optuna trials
+# removed: study_name — legacy Optuna study setting; networkmodel always uses JAXopt
+# removed: sampler — legacy Optuna sampler setting; networkmodel always uses JAXopt
+# removed: pruner — legacy Optuna pruner setting; networkmodel always uses JAXopt
+# removed: n_trials — legacy Optuna trial count; networkmodel always uses JAXopt
 
 # ------------------------------------------------------------
-# OPTIMIZATION PARAMETERS (Pymoo)
+# OPTIMIZATION PARAMETERS (JAXopt)
 # ------------------------------------------------------------
-n_gen      = 20000                       # Generations (runner arg: --n-gen)
-pop        = 300                       # Population size (runner arg: --pop)
-refine     = false                     # Run 2nd pass with tighter bounds (runner arg: --refine)
-num_refinements = 0                       # Number of refinements
+n_gen      = 20000                       # Maximum local optimizer iterations (runner arg: --n-gen)
+# removed: pop — legacy evolutionary population size; JAXopt local optimization does not use populations
+# removed: refine — legacy second-pass refinement; scalar JAXopt mode is already deterministic local optimization
+# removed: num_refinements — legacy refinement iteration count; scalar JAXopt mode does not run refinement passes
 loss = 0
 # Loss type (0: MSE, 1:Huber, 2:Psuedo-Huber, 3:Log-Cosh, 4:Cauchy, 5:Poisson, 6:Geman-McClure)
 # -1 for Charbonnier Loss
@@ -355,6 +355,19 @@ sensitivity_top_curves = 20              # Number of top curves to plot in sensi
 sensitivity_metric = "total_signal"          #  ["total_signal", "mean", "variance", "l2_norm"]
 # ------------------------------------------------------------
 
+# ------------------------------------------------------------
+# INFERENCE / POST-OPTIMIZATION ANALYSES
+# ------------------------------------------------------------
+# --- Inference / Multistart ---
+n_starts = 1               # int: restarts; 1 = single-start (current behaviour)
+# --- Profile Likelihood (post-optimization) ---
+profile_likelihood = false
+profile_indices = ""       # comma-separated parameter indices e.g. "0,1,5"
+profile_grid_size = 10
+# --- Posterior Sampling (post-optimization, requires numpyro) ---
+posterior_sampling = false
+posterior_num_warmup = 20
+posterior_num_samples = 30
 
 # MODEL & BOUNDS CONFIGURATION
 # ------------------------------------------------------------
@@ -403,4 +416,4 @@ default_model = "distributive"
 absolute_tolerance = 1e-8
 relative_tolerance = 1e-8
 max_timesteps = 200000
-use_custom_solver = false
+# removed: use_custom_solver — legacy custom ODE backend toggle; networkmodel always uses Diffrax Kvaerno

--- a/config_loader.py
+++ b/config_loader.py
@@ -125,18 +125,14 @@ class PhosKinConfig:
     bounds_config: dict[str, tuple[float, float]]
     model: str
 
-    use_custom_solver: bool
     ode_abs_tol: float
     ode_rel_tol: float
     ode_max_steps: int
 
     loss_mode: int
     maximum_iterations: int
-    population_size: int
     seed: int
     cores: int
-    refine: bool
-    num_refine: int
 
     regularization_rna: float
     regularization_lambda: float
@@ -155,13 +151,14 @@ class PhosKinConfig:
 
     hyperparam_scan: bool = False
 
-    optimizer: str = "pymoo"  # "optuna" or "pymoo"
-
-    # Optuna-specific knobs
-    study_name: str = ""
-    sampler: str = "TPESampler"
-    pruner: str = "MedianPruner"
-    n_trials: int = 0
+    # Inference / post-optimization analyses
+    n_starts: int = 1
+    profile_likelihood: bool = False
+    profile_indices: str = ""
+    profile_grid_size: int = 10
+    posterior_sampling: bool = False
+    posterior_num_warmup: int = 20
+    posterior_num_samples: int = 30
 
     # Data scaling & weighting
     scaling_method: str = "none"
@@ -221,8 +218,6 @@ def load_config_toml(path: str | Path) -> PhosKinConfig:
     res_dir = cfg.get("output_dir", cfg.get("output_directory", "results_global"))
     cores = int(cfg.get("cores", 0))
     seed = int(cfg.get("seed", 42))
-    refine = bool(cfg.get("refine", False))
-    num_refine = int(cfg.get("num_refinements", cfg.get("num_refine", 0)))
 
     # -------------------------
     # 3) Data inference flags
@@ -254,24 +249,23 @@ def load_config_toml(path: str | Path) -> PhosKinConfig:
     available_models = tuple(models_cfg.get("available_models", []) or [])
 
     # -------------------------
-    # 6) Optimizer selection + params
+    # 6) JAXopt optimizer params
     # -------------------------
-    optimizer = str(cfg.get("optimizer", "pymoo")).strip().lower()
-
     hyp_scan = bool(cfg.get("hyperparam_scan", False))
 
-    # Pymoo-style knobs
     max_iter = int(cfg.get("n_gen", 200))
-    pop_size = int(cfg.get("pop", 100))
 
     # Loss
     loss_mode = int(cfg.get("loss", 0))
 
-    # Optuna knobs
-    study_name = str(cfg.get("study_name", ""))
-    sampler = str(cfg.get("sampler", "TPESampler"))
-    pruner = str(cfg.get("pruner", "MedianPruner"))
-    n_trials = int(cfg.get("n_trials", 0))
+    # Inference / post-optimization analyses
+    n_starts = int(cfg.get("n_starts", 1))
+    profile_likelihood = bool(cfg.get("profile_likelihood", False))
+    profile_indices = str(cfg.get("profile_indices", ""))
+    profile_grid_size = int(cfg.get("profile_grid_size", 10))
+    posterior_sampling = bool(cfg.get("posterior_sampling", False))
+    posterior_num_warmup = int(cfg.get("posterior_num_warmup", 20))
+    posterior_num_samples = int(cfg.get("posterior_num_samples", 30))
 
     # -------------------------
     # 7) Regularization (loss weights)
@@ -287,7 +281,6 @@ def load_config_toml(path: str | Path) -> PhosKinConfig:
     # 8) Solver
     # -------------------------
     sol_cfg = cfg.get("solver", {}) or {}
-    use_custom_solver = bool(sol_cfg.get("use_custom_solver", False))
     ode_abs_tol = float(sol_cfg.get("absolute_tolerance", 1e-8))
     ode_rel_tol = float(sol_cfg.get("relative_tolerance", 1e-8))
     ode_max_steps = int(sol_cfg.get("max_timesteps", 200000))
@@ -342,20 +335,15 @@ def load_config_toml(path: str | Path) -> PhosKinConfig:
 
         model=model,
 
-        use_custom_solver=use_custom_solver,
         ode_abs_tol=ode_abs_tol,
         ode_rel_tol=ode_rel_tol,
         ode_max_steps=ode_max_steps,
 
         loss_mode=loss_mode,
         maximum_iterations=max_iter,
-        population_size=pop_size,
 
         seed=seed,
         cores=cores,
-
-        refine=refine,
-        num_refine=num_refine,
 
         regularization_rna=reg_rna,
         regularization_lambda=reg_lambda,
@@ -374,11 +362,13 @@ def load_config_toml(path: str | Path) -> PhosKinConfig:
 
         hyperparam_scan=hyp_scan,
 
-        optimizer=optimizer,
-        study_name=study_name,
-        sampler=sampler,
-        pruner=pruner,
-        n_trials=n_trials,
+        n_starts=n_starts,
+        profile_likelihood=profile_likelihood,
+        profile_indices=profile_indices,
+        profile_grid_size=profile_grid_size,
+        posterior_sampling=posterior_sampling,
+        posterior_num_warmup=posterior_num_warmup,
+        posterior_num_samples=posterior_num_samples,
 
         scaling_method=scaling_method,
 

--- a/networkmodel/config.py
+++ b/networkmodel/config.py
@@ -72,8 +72,7 @@ MODEL = 0 if cfg.model == "distributive" else (
     1 if cfg.model == "sequential" else (2 if cfg.model == "combinatorial" else 4)
 )
 
-# Solver precision and custom backend selection
-USE_CUSTOM_SOLVER = _as_bool(cfg.use_custom_solver)
+# Solver precision for the Diffrax Kvaerno backend
 ODE_ABS_TOL = cfg.ode_abs_tol
 ODE_REL_TOL = cfg.ode_rel_tol
 ODE_MAX_STEPS = cfg.ode_max_steps
@@ -81,11 +80,8 @@ ODE_MAX_STEPS = cfg.ode_max_steps
 # --- Optimization Settings ---
 LOSS_MODE = cfg.loss_mode
 MAX_ITERATIONS = cfg.maximum_iterations
-POPULATION_SIZE = cfg.population_size  # Number of particles/individuals in the optimizer
 SEED = cfg.seed
 CORES = cfg.cores  # Multiprocessing core count
-REFINE = _as_bool(cfg.refine)  # Whether to run a local optimization polish after global search
-NUM_REFINE = cfg.num_refine  # Number of iterations for the refinement step
 
 # --- Regularization ---
 # Penalties to enforce biological constraints (e.g., sparsity, smooth trajectories)
@@ -111,17 +107,14 @@ DOCS_URL = getattr(cfg, "docs_url", "")
 # Flag to enable grid/random search over model hyperparameters (e.g., penalties)
 HYPERPARAM_SCAN = getattr(cfg, "hyperparam_scan", False)
 
-# --- Optimizer selection ---
-# Legacy optimizer names are still accepted by CLI/config, but the PhosKinTime
-# networkmodel/protwise execution path maps them to JAXopt internally.
-OPTIMIZER = getattr(cfg, "optimizer", "pymoo")
-
-# --- Optuna settings ---
-# Specific settings if OPTIMIZER == 'optuna'
-STUDY_NAME = getattr(cfg, "study_name", "")
-SAMPLER = getattr(cfg, "sampler", "TPESampler")
-PRUNER = getattr(cfg, "pruner", "MedianPruner")
-N_TRIALS = getattr(cfg, "n_trials", 0)
+# --- Inference / post-optimization analyses ---
+N_STARTS = int(getattr(cfg, "n_starts", 1))
+PROFILE_LIKELIHOOD = _as_bool(getattr(cfg, "profile_likelihood", False))
+PROFILE_INDICES = str(getattr(cfg, "profile_indices", ""))
+PROFILE_GRID_SIZE = int(getattr(cfg, "profile_grid_size", 10))
+POSTERIOR_SAMPLING = _as_bool(getattr(cfg, "posterior_sampling", False))
+POSTERIOR_NUM_WARMUP = int(getattr(cfg, "posterior_num_warmup", 20))
+POSTERIOR_NUM_SAMPLES = int(getattr(cfg, "posterior_num_samples", 30))
 
 # --- Data scaling / weighting ---
 # Methods to balance the influence of different datasets (RNA vs Protein vs Phospho)

--- a/networkmodel/runner.py
+++ b/networkmodel/runner.py
@@ -629,7 +629,7 @@ def main():
         f"[Data] Number of points: {loss_data['n_p']} protein, {loss_data['n_r']} RNA, "
         f"{loss_data['n_ph']} phospho | Total {loss_data['n_p'] + loss_data['n_r'] + loss_data['n_ph']} data points"
     )
-    configure_jax_parallelism(max_workers=CORES, logger_obj=logger)
+    configure_jax_parallelism(max_workers=args.cores, logger_obj=logger)
     ctx = InferenceContext(
         objective_fun=problem.objective,
         theta0=theta0,
@@ -643,7 +643,7 @@ def main():
     )
     if N_STARTS > 1:
         try:
-            ms = run_multistart(ctx, n_starts=N_STARTS, seed=SEED, max_workers=CORES)
+            ms = run_multistart(ctx, n_starts=N_STARTS, seed=args.seed, max_workers=args.cores)
             best_row = ms["best"].drop(
                 columns=["start_id", "seed", "success", "selected_best"],
                 errors="ignore",
@@ -651,6 +651,13 @@ def main():
             best_x = np.asarray(best_row.values, dtype=np.float64)
             best_f = float(ms["summary"].loc[ms["summary"]["selected_best"], "final_objective"].iloc[0])
             opt_state = None
+            # Repopulate problem.final_loss_breakdown from the winning parameters.
+            try:
+                objective_raw = getattr(problem, "objective_raw", problem._objective_raw)
+                _, breakdown = objective_raw(best_x)
+                problem.final_loss_breakdown = {k: float(v) for k, v in breakdown.items()}
+            except Exception as e:
+                logger.warning("Could not repopulate loss breakdown after multistart: %s", e)
         except RuntimeError:
             logger.warning("Multistart failed; falling back to single-start solve.")
             best_x, opt_state, best_f = problem.solve(theta0, maxiter=args.n_gen)
@@ -666,6 +673,19 @@ def main():
         data_mode=mode,
         loss_breakdown=dict(problem.final_loss_breakdown),
     )
+    # Replace the original ctx with a post-optimization version.
+    # Only theta0 changes — everything else is identical.
+    ctx = InferenceContext(
+        objective_fun=problem.objective,
+        theta0=best_x,
+        lower=xl,
+        upper=xu,
+        mode=mode,
+        output_dir=args.output_dir,
+        parameter_names=None,
+        maxiter=args.n_gen,
+        tol=1e-6,
+    )
     if PROFILE_LIKELIHOOD and PROFILE_INDICES.strip():
         profile_indices = [int(x) for x in PROFILE_INDICES.split(",") if x.strip()]
         run_profile_likelihood(ctx, parameter_indices=profile_indices,
@@ -674,7 +694,7 @@ def main():
     if POSTERIOR_SAMPLING:
         try:
             run_numpyro_posterior(ctx, num_warmup=POSTERIOR_NUM_WARMUP,
-                                  num_samples=POSTERIOR_NUM_SAMPLES, seed=SEED)
+                                  num_samples=POSTERIOR_NUM_SAMPLES, seed=args.seed)
             logger.info("Posterior sampling complete.")
         except RuntimeError as e:
             logger.warning("Posterior sampling skipped: %s", e)

--- a/networkmodel/runner.py
+++ b/networkmodel/runner.py
@@ -39,12 +39,13 @@ import pandas as pd
 from networkmodel.buildmat import build_W_parallel, build_tf_matrix
 from networkmodel.cache import prepare_fast_loss_data
 from networkmodel.config import TIME_POINTS_PROTEIN, TIME_POINTS_RNA, RESULTS_DIR, MAX_ITERATIONS, \
-    POPULATION_SIZE, SEED, REGULARIZATION_LAMBDA, REGULARIZATION_RNA, REGULARIZATION_PHOSPHO, TIME_POINTS_PHOSPHO, \
+    SEED, REGULARIZATION_LAMBDA, REGULARIZATION_RNA, REGULARIZATION_PHOSPHO, TIME_POINTS_PHOSPHO, \
     REGULARIZATION_PROTEIN, NORMALIZE_FC_STEADY, USE_INITIAL_CONDITION_FROM_DATA, KINASE_NET_FILE, TF_NET_FILE, \
-    MS_DATA_FILE, RNA_DATA_FILE, PHOSPHO_DATA_FILE, KINOPT_RESULTS_FILE, TFOPT_RESULTS_FILE, REFINE, \
+    MS_DATA_FILE, RNA_DATA_FILE, PHOSPHO_DATA_FILE, KINOPT_RESULTS_FILE, TFOPT_RESULTS_FILE, \
     WEIGHTING_METHOD_PROTEIN, WEIGHTING_METHOD_RNA, APP_NAME, VERSION, PARENT_PACKAGE, CITATION, DOI, GITHUB_URL, \
-    DOCS_URL, SENSITIVITY_METRIC, SENSITIVITY_ANALYSIS, AVAILABLE_MODELS, OPTIMIZER, HYPERPARAM_SCAN, MODEL, \
-    USE_CUSTOM_SOLVER, CORES
+    DOCS_URL, SENSITIVITY_METRIC, SENSITIVITY_ANALYSIS, AVAILABLE_MODELS, HYPERPARAM_SCAN, MODEL, CORES, \
+    N_STARTS, PROFILE_LIKELIHOOD, PROFILE_INDICES, PROFILE_GRID_SIZE, POSTERIOR_SAMPLING, \
+    POSTERIOR_NUM_WARMUP, POSTERIOR_NUM_SAMPLES
 from networkmodel.io import load_data
 from networkmodel.network import Index, KinaseInput, System
 from networkmodel.optproblem import GlobalODEScalarObjective, build_weight_functions
@@ -58,6 +59,11 @@ from networkmodel.export import export_pareto_front_to_excel, plot_goodness_of_f
     export_param_correlations, export_residuals, export_parameter_distributions
 from networkmodel.analysis import simulate_until_steady, plot_steady_state_all
 from networkmodel.jax_backend import warn_deprecated_backend_options, detect_data_mode, JaxoptResult
+from networkmodel.inference import (
+    InferenceContext, run_multistart,
+    run_profile_likelihood, run_numpyro_posterior,
+    configure_jax_parallelism,
+)
 from networkmodel.mode_outputs import write_scalar_result_tables
 from common.frechet import frechet_distance
 from config_loader import load_config_toml
@@ -93,9 +99,8 @@ def main():
     parser.add_argument("--output-dir", default=RESULTS_DIR)
     parser.add_argument("--cores", type=int, default=CORES)
 
-    # Pymoo
+    # JAXopt
     parser.add_argument("--n-gen", type=int, default=MAX_ITERATIONS)
-    parser.add_argument("--pop", type=int, default=POPULATION_SIZE)
     parser.add_argument("--seed", type=int, default=SEED)
 
     # Loss weights
@@ -108,16 +113,13 @@ def main():
     parser.add_argument("--normalize-fc-steady", action="store_true", default=NORMALIZE_FC_STEADY)
     parser.add_argument("--use-initial-condition-from-data", action="store_true",
                         default=USE_INITIAL_CONDITION_FROM_DATA)
-    parser.add_argument("--refine", action="store_true",
-                        help="Run a second optimization pass with tighter bounds around the scalar optimum.",
-                        default=REFINE)
     parser.add_argument("--scan", action="store_true",
                         help="Run a hyperparameter scan using Optuna to find the best regularization parameters.",
                         default=HYPERPARAM_SCAN)
     parser.add_argument("--sensitivity", action="store_true",
                         help="Run a sensitivity analysis after optimization.",
                         default=SENSITIVITY_ANALYSIS)
-    parser.add_argument("--solver", type=str, choices=["jaxopt", "pymoo", "optuna"], default=OPTIMIZER,
+    parser.add_argument("--solver", type=str, choices=["jaxopt", "pymoo", "optuna"], default="jaxopt",
                         help="Choice of optimization solver. Legacy pymoo/optuna values map to jaxopt.")
 
     args = parser.parse_args()
@@ -138,10 +140,7 @@ def main():
     logger.info(f"Documentation      : {DOCS_URL}")
     logger.info("============================================================")
 
-    if USE_CUSTOM_SOLVER:
-        logger.info("[Solver] Using Custom Adaptive Heun Bucketed Solver")
-    else:
-        logger.info("[Solver] Using Diffrax Kvaerno Solver")
+    logger.info("[Solver] Using Diffrax Kvaerno Solver")
 
     if MODEL == 0:
         logger.info("[Model] Using Distributive Model")
@@ -157,7 +156,6 @@ def main():
     logger.info(f"[Args] Output directory: {args.output_dir}")
     logger.info(f"[Args] Number of cores: {args.cores}")
     logger.info(f"[Args] Number of generations: {args.n_gen}")
-    logger.info(f"[Args] Population size: {args.pop}")
     logger.info(f"[Args] Seed: {args.seed}")
     logger.info(f"[Args] Lambda prior: {args.lambda_prior}")
     logger.info(f"[Args] Lambda protein: {args.lambda_protein}")
@@ -631,7 +629,34 @@ def main():
         f"[Data] Number of points: {loss_data['n_p']} protein, {loss_data['n_r']} RNA, "
         f"{loss_data['n_ph']} phospho | Total {loss_data['n_p'] + loss_data['n_r'] + loss_data['n_ph']} data points"
     )
-    best_x, opt_state, best_f = problem.solve(theta0, maxiter=args.n_gen)
+    configure_jax_parallelism(max_workers=CORES, logger_obj=logger)
+    ctx = InferenceContext(
+        objective_fun=problem.objective,
+        theta0=theta0,
+        lower=xl,
+        upper=xu,
+        mode=mode,
+        output_dir=args.output_dir,
+        parameter_names=None,
+        maxiter=args.n_gen,
+        tol=1e-6,
+    )
+    if N_STARTS > 1:
+        try:
+            ms = run_multistart(ctx, n_starts=N_STARTS, seed=SEED, max_workers=CORES)
+            best_row = ms["best"].drop(
+                columns=["start_id", "seed", "success", "selected_best"],
+                errors="ignore",
+            ).iloc[0]
+            best_x = np.asarray(best_row.values, dtype=np.float64)
+            best_f = float(ms["summary"].loc[ms["summary"]["selected_best"], "final_objective"].iloc[0])
+            opt_state = None
+        except RuntimeError:
+            logger.warning("Multistart failed; falling back to single-start solve.")
+            best_x, opt_state, best_f = problem.solve(theta0, maxiter=args.n_gen)
+    else:
+        best_x, opt_state, best_f = problem.solve(theta0, maxiter=args.n_gen)
+
     res = JaxoptResult(
         X=np.asarray([best_x], dtype=float),
         F=np.asarray([[best_f]], dtype=float),
@@ -641,6 +666,18 @@ def main():
         data_mode=mode,
         loss_breakdown=dict(problem.final_loss_breakdown),
     )
+    if PROFILE_LIKELIHOOD and PROFILE_INDICES.strip():
+        profile_indices = [int(x) for x in PROFILE_INDICES.split(",") if x.strip()]
+        run_profile_likelihood(ctx, parameter_indices=profile_indices,
+                               grid_size=PROFILE_GRID_SIZE)
+        logger.info("Profile likelihood complete.")
+    if POSTERIOR_SAMPLING:
+        try:
+            run_numpyro_posterior(ctx, num_warmup=POSTERIOR_NUM_WARMUP,
+                                  num_samples=POSTERIOR_NUM_SAMPLES, seed=SEED)
+            logger.info("Posterior sampling complete.")
+        except RuntimeError as e:
+            logger.warning("Posterior sampling skipped: %s", e)
     # Save full result object
     with open(os.path.join(args.output_dir, f"{args.solver}_optimization_result.pkl"), "wb") as f:
         pickle.dump(res, f)

--- a/tests/test_networkmodel_inference_config.py
+++ b/tests/test_networkmodel_inference_config.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import inspect
+
+from config_loader import load_config_toml
+import networkmodel.config as config
+import networkmodel.runner as runner
+
+
+def test_inference_config_defaults_are_loaded():
+    cfg = load_config_toml("config.toml")
+
+    assert cfg.n_starts == 1
+    assert cfg.profile_likelihood is False
+    assert cfg.profile_indices == ""
+    assert cfg.profile_grid_size == 10
+    assert cfg.posterior_sampling is False
+    assert cfg.posterior_num_warmup == 20
+    assert cfg.posterior_num_samples == 30
+
+    assert config.N_STARTS == 1
+    assert config.PROFILE_LIKELIHOOD is False
+    assert config.PROFILE_INDICES == ""
+    assert config.PROFILE_GRID_SIZE == 10
+    assert config.POSTERIOR_SAMPLING is False
+    assert config.POSTERIOR_NUM_WARMUP == 20
+    assert config.POSTERIOR_NUM_SAMPLES == 30
+
+
+def test_legacy_networkmodel_config_fields_are_not_exported():
+    cfg = load_config_toml("config.toml")
+
+    for field in (
+        "population_size",
+        "use_custom_solver",
+        "optimizer",
+        "study_name",
+        "sampler",
+        "pruner",
+        "n_trials",
+        "refine",
+        "num_refine",
+    ):
+        assert not hasattr(cfg, field)
+
+    for constant in (
+        "POPULATION_SIZE",
+        "USE_CUSTOM_SOLVER",
+        "OPTIMIZER",
+        "STUDY_NAME",
+        "SAMPLER",
+        "PRUNER",
+        "N_TRIALS",
+        "REFINE",
+        "NUM_REFINE",
+    ):
+        assert not hasattr(config, constant)
+
+
+def test_runner_wires_inference_without_new_legacy_config_imports():
+    source = inspect.getsource(runner)
+
+    assert "from networkmodel.inference import" in source
+    assert "InferenceContext" in source
+    assert "run_multistart" in source
+    assert "run_profile_likelihood" in source
+    assert "run_numpyro_posterior" in source
+    assert "configure_jax_parallelism" in source
+    assert "parser.add_argument(\"--pop\"" not in source
+    assert "parser.add_argument(\"--refine\"" not in source


### PR DESCRIPTION
### Motivation
- Remove dead evolutionary/protwise/legacy ODE backend configuration and expose inference/post-optimization controls so the JAXopt+Diffrax networkmodel path can use `inference.py` features via `config.toml` and the existing config loader.
- Integrate multistart/profile-likelihood/posterior-sampling flows into `runner.py` while keeping `jax_backend.py` and `inference.py` unchanged and without adding new CLI arguments.

### Description
- Removed legacy solver/evolutionary/protwise config keys from `config.toml` and added a clearly labelled `# INFERENCE / POST-OPTIMIZATION ANALYSES` section with `n_starts`, `profile_likelihood`, `profile_indices`, `profile_grid_size`, `posterior_sampling`, `posterior_num_warmup`, and `posterior_num_samples`.
- Updated the config loader (`config_loader.py`)/`PhosKinConfig` to stop exporting legacy fields (e.g. `population_size`, `use_custom_solver`, `optimizer`, Optuna/Pymoo knobs and refinement fields) and to parse the new inference/profile/posterior fields using the existing `getattr`/conversion patterns.
- Modified `networkmodel/config.py` to remove constants tied only to legacy backends and to export the new constants `N_STARTS`, `PROFILE_LIKELIHOOD`, `PROFILE_INDICES`, `PROFILE_GRID_SIZE`, `POSTERIOR_SAMPLING`, `POSTERIOR_NUM_WARMUP`, and `POSTERIOR_NUM_SAMPLES`.
- Wired `networkmodel/runner.py` to import `InferenceContext`, `run_multistart`, `run_profile_likelihood`, `run_numpyro_posterior`, and `configure_jax_parallelism` from `networkmodel.inference`; replaced the single-call `problem.solve(...)` with an `InferenceContext`-driven multistart branch (when `N_STARTS>1`) and added optional post-optimization blocks that call profile-likelihood and NumPyro posterior sampling; removed legacy CLI knobs `--pop` and `--refine` and set the solver default to `"jaxopt"` so default behavior remains the same when the new fields are at defaults.

### Testing
- Compiled modified modules with `python -m py_compile config_loader.py networkmodel/config.py networkmodel/runner.py` and the compilation succeeded.
- Verified `load_config_toml('config.toml')` returns the new inference defaults and that the removed legacy fields are not present, and asserted the new constants import from `networkmodel.config` (smoke tests succeeded).
- Performed a smoke import of `networkmodel.runner` to ensure there are no import-time errors (succeeded).
- Added and ran `PYTHONPATH=. pytest -q tests/test_networkmodel_inference_config.py` which passed (tests confirming defaults, removed legacy exports, and runner wiring).
- Ran a subset of the existing integration tests (`tests/test_phoskintime_jax_multimodal.py` and `tests/test_protwise_parameterization.py`) with `PYTHONPATH=.`, which executed but reported 4 existing test failures unrelated to the config wiring (one `GlobalODEScalarObjective` slice/bounds mismatch and three `pytest.approx` nested-list compatibility issues) while many other tests passed; these failures pre-existed and were not introduced by the inference wiring.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f41e0ac4c83279bb7d4bc3759d8e8)