### PR TITLE
Add optional pure-JAX network_preprocessing module (hyperedge discovery, pruning, motifs, sparse theta, identifiability)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -982,6 +982,57 @@ sensitivity_metric = "l2_norm"
 
 
 # ------------------------------------------------------------
+# HYPEREDGE / NETWORK PREPROCESSING
+# ------------------------------------------------------------
+# Optional pure-JAX preprocessing that discovers, scores, prunes, annotates,
+# and exports kinase-site-substrate triplets before networkmodel ODE construction.
+#
+# Default behavior is disabled so existing PhosKinTime workflows remain unchanged.
+[networkmodel.hyperedge_preprocessing]
+
+# Enable optional preprocessing before Index/model construction.
+# false: keep existing networkmodel behavior exactly unchanged.
+# true : run the independent pure-JAX preprocessing module and pass its pruned
+#        kinase network to downstream model construction.
+enable_hyperedge_preprocessing = false
+
+# Subdirectory name used under standard run result folders, e.g.
+# tables/network_preprocessing and plots/network_preprocessing.
+output_subdir = "network_preprocessing"
+
+# Minimum score used during discovery/reporting. Must be >= 0.0.
+hyperedge_discovery_threshold = 0.0
+
+# Minimum score retained during pruning. Must be >= 0.0.
+hyperedge_pruning_threshold = 0.0
+
+# Detect feed-forward loops, kinase cascades, regulatory triangles, and related
+# 3-node motifs from retained triplets.
+motif_detection = true
+
+# Export sparse COO-like theta tensor indices/values as CSV and NPZ.
+sparse_tensor_export = true
+
+# Run structural identifiability preprocessing diagnostics before fitting.
+identifiability_preprocessing = true
+
+# Optional maximum number of retained triplets for memory safety.
+# Use 0 for no explicit cap. Negative values are invalid.
+max_triplets = 0
+
+# Batch size for JAX kernels and chunked preprocessing. Must be positive.
+batch_size = 65536
+
+# Save diagnostic plots for score distributions, motifs, sparsity, and
+# identifiability.
+plot_generation = true
+
+# Save labelled CSV/JSON tables for discovered/pruned triplets, motifs,
+# identifiability diagnostics, and summary statistics.
+csv_export = true
+
+
+# ------------------------------------------------------------
 # INFERENCE / POST-OPTIMIZATION ANALYSES
 # ------------------------------------------------------------
 

--- a/config_loader.py
+++ b/config_loader.py
@@ -177,6 +177,71 @@ class PhosKinConfig:
     # Models metadata
     available_models: tuple[str, ...] = ()
 
+    # Optional pure-JAX hyperedge/network preprocessing
+    enable_hyperedge_preprocessing: bool = False
+    hyperedge_preprocessing_output_subdir: str = "network_preprocessing"
+    hyperedge_discovery_threshold: float = 0.0
+    hyperedge_pruning_threshold: float = 0.0
+    hyperedge_motif_detection: bool = True
+    hyperedge_sparse_tensor_export: bool = True
+    hyperedge_identifiability_preprocessing: bool = True
+    hyperedge_max_triplets: int | None = None
+    hyperedge_batch_size: int = 65536
+    hyperedge_plot_generation: bool = True
+    hyperedge_csv_export: bool = True
+
+
+def _parse_hyperedge_preprocessing_config(cfg: dict[str, Any]) -> dict[str, Any]:
+    """Parse and validate optional pure-JAX hyperedge preprocessing settings."""
+    prep = cfg.get("hyperedge_preprocessing", {}) or {}
+
+    def _bool(name: str, default: bool) -> bool:
+        raw = prep.get(name, default)
+        if isinstance(raw, bool):
+            return raw
+        if isinstance(raw, str):
+            return raw.strip().lower() in {"1", "true", "yes", "y", "on"}
+        return bool(raw)
+
+    def _float_nonnegative(name: str, default: float) -> float:
+        value = float(prep.get(name, default))
+        if value < 0.0:
+            raise ValueError(f"networkmodel.hyperedge_preprocessing.{name} must be non-negative, got {value}")
+        return value
+
+    def _nonnegative_int_cap(name: str, default: int | None) -> int | None:
+        raw = prep.get(name, default)
+        if raw is None:
+            return None
+        value = int(raw)
+        if value < 0:
+            raise ValueError(f"networkmodel.hyperedge_preprocessing.{name} must be non-negative, got {value}")
+        return None if value == 0 else value
+
+    def _positive_int(name: str, default: int) -> int:
+        value = int(prep.get(name, default))
+        if value <= 0:
+            raise ValueError(f"networkmodel.hyperedge_preprocessing.{name} must be positive, got {value}")
+        return value
+
+    output_subdir = str(prep.get("output_subdir", "network_preprocessing")).strip()
+    if not output_subdir:
+        raise ValueError("networkmodel.hyperedge_preprocessing.output_subdir must be a non-empty string")
+
+    return {
+        "enable_hyperedge_preprocessing": _bool("enable_hyperedge_preprocessing", False),
+        "hyperedge_preprocessing_output_subdir": output_subdir,
+        "hyperedge_discovery_threshold": _float_nonnegative("hyperedge_discovery_threshold", 0.0),
+        "hyperedge_pruning_threshold": _float_nonnegative("hyperedge_pruning_threshold", 0.0),
+        "hyperedge_motif_detection": _bool("motif_detection", True),
+        "hyperedge_sparse_tensor_export": _bool("sparse_tensor_export", True),
+        "hyperedge_identifiability_preprocessing": _bool("identifiability_preprocessing", True),
+        "hyperedge_max_triplets": _nonnegative_int_cap("max_triplets", 0),
+        "hyperedge_batch_size": _positive_int("batch_size", 65536),
+        "hyperedge_plot_generation": _bool("plot_generation", True),
+        "hyperedge_csv_export": _bool("csv_export", True),
+    }
+
 
 def load_config_toml(path: str | Path) -> PhosKinConfig:
     path = Path(path)
@@ -313,6 +378,11 @@ def load_config_toml(path: str | Path) -> PhosKinConfig:
     sensitivity_top_curves = int(cfg.get("sensitivity_top_curves", 50))  # key matches TOML
     sensitivity_metric = str(cfg.get("sensitivity_metric", "total_signal"))
 
+    # -------------------------
+    # 12) Optional hyperedge/network preprocessing
+    # -------------------------
+    hyperedge_cfg = _parse_hyperedge_preprocessing_config(cfg)
+
     return PhosKinConfig(
         kinase_net=kinase_net,
         tf_net=tf_net,
@@ -384,4 +454,6 @@ def load_config_toml(path: str | Path) -> PhosKinConfig:
         sensitivity_metric=sensitivity_metric,
 
         available_models=available_models,
+
+        **hyperedge_cfg,
     )

--- a/network_preprocessing/__init__.py
+++ b/network_preprocessing/__init__.py
@@ -1,0 +1,2 @@
+from .dataclasses import *
+from .api import preprocess_network, preprocess_networkmodel_frames, discover_hyperedges, prune_triplets, detect_motifs, build_sparse_theta, preprocess_identifiability

--- a/network_preprocessing/api.py
+++ b/network_preprocessing/api.py
@@ -83,9 +83,31 @@ def preprocess_network(kinase_network: pd.DataFrame, *, phospho_observations=Non
         logger.info("[NetworkPreprocessing] outputs saved under %s", Path(output_dir)/config.output_subdir)
     return res
 
+def _pruned_networkmodel_frame(result: NetworkPreprocessingResult) -> pd.DataFrame:
+    enc = result.encoded
+    retained = {
+        (int(k), int(s), int(sub))
+        for k, s, sub in zip(result.pruned.kinase_ids, result.pruned.site_ids, result.pruned.substrate_ids)
+    }
+    rows = []
+    for k, s, sub, alpha, support in zip(
+        enc.kinase_ids, enc.site_ids, enc.substrate_ids, enc.edge_weight, enc.support_count
+    ):
+        key = (int(k), int(s), int(sub))
+        if key not in retained:
+            continue
+        site_label = enc.site_labels[key[1]]
+        protein, psite = site_label.split(":", 1)
+        rows.append({
+            "protein": protein,
+            "psite": psite,
+            "kinase": enc.kinase_labels[key[0]],
+            "alpha": float(alpha),
+            "support_count": int(support),
+        })
+    return pd.DataFrame(rows, columns=["protein", "psite", "kinase", "alpha", "support_count"])
+
+
 def preprocess_networkmodel_frames(df_kin, df_tf, df_prot, df_pho, df_rna, *, config=None, output_dir=None, logger=None):
     res=preprocess_network(df_kin, phospho_observations=df_pho, protein_observations=df_prot, rna_observations=df_rna, tf_network=df_tf, config=config, output_dir=output_dir, logger=logger)
-    enc=res.encoded
-    retained={(enc.kinase_labels[int(k)], enc.site_labels[int(s)].split(":",1)[0], enc.site_labels[int(s)].split(":",1)[1]) for k,s in zip(res.pruned.kinase_ids, res.pruned.site_ids)}
-    out=df_kin.copy(); mask=[(str(r.kinase).strip().upper(), str(r.protein).strip().upper(), str(r.psite).strip()) in retained for r in out.itertuples()]
-    return out.loc[mask].copy(), res
+    return _pruned_networkmodel_frame(res), res

--- a/network_preprocessing/api.py
+++ b/network_preprocessing/api.py
@@ -14,7 +14,7 @@ def discover_hyperedges(encoded: EncodedNetwork, config: NetworkPreprocessingCon
     return TripletTable(encoded.kinase_ids, encoded.site_ids, encoded.substrate_ids, score, encoded.support_count, jnp.zeros_like(encoded.support_count, dtype=jnp.uint32))
 
 def prune_triplets(triplets: TripletTable, encoded: EncodedNetwork, config: NetworkPreprocessingConfig) -> TripletTable:
-    flags=pruning_flags(triplets.score, triplets.support_count, encoded.site_observed, encoded.kinase_observed, triplets.kinase_ids, triplets.substrate_ids, float(config.min_triplet_score), int(config.min_support_count), bool(config.prune_self_loops), bool(config.prune_missing_observations))
+    flags=pruning_flags(triplets.score, triplets.support_count, encoded.site_observed, encoded.kinase_observed, triplets.kinase_ids, triplets.substrate_ids, float(max(config.discovery_threshold, config.min_triplet_score)), int(config.min_support_count), bool(config.prune_self_loops), bool(config.prune_missing_observations))
     keep=flags==0
     if config.max_triplets is not None and int(keep.sum())>config.max_triplets:
         kept_idx=jnp.where(keep, size=triplets.score.size, fill_value=-1)[0]
@@ -58,9 +58,15 @@ def preprocess_network(kinase_network: pd.DataFrame, *, phospho_observations=Non
     summary={"n_discovered": int(discovered.score.size), "n_retained": int(pruned.score.size), "n_pruned": int(discovered.score.size-pruned.score.size), "n_motifs": int(0 if motifs is None else motifs.score.size), "tensor_nnz": int(theta.values.size)}
     res=NetworkPreprocessingResult(encoded, discovered, pruned, theta, motifs, ident, summary)
     if output_dir is not None:
-        from .export import export_preprocessing_result
-        from .plotting import plot_preprocessing_result
-        export_preprocessing_result(res, output_dir); plot_preprocessing_result(res, output_dir)
+        if config.export_csv or config.export_sparse_tensor:
+            from .export import export_preprocessing_result
+            export_preprocessing_result(
+                res, output_dir, output_subdir=config.output_subdir,
+                include_csv=config.export_csv, include_sparse_tensor=config.export_sparse_tensor,
+            )
+        if config.generate_plots:
+            from .plotting import plot_preprocessing_result
+            plot_preprocessing_result(res, output_dir, output_subdir=config.output_subdir)
         logger.info("[NetworkPreprocessing] outputs saved under %s", Path(output_dir)/config.output_subdir)
     return res
 

--- a/network_preprocessing/api.py
+++ b/network_preprocessing/api.py
@@ -10,11 +10,11 @@ from .io_adapters import encode_kinase_network
 from .jax_kernels import score_triplets, pruning_flags, sparse_indices_values
 
 def discover_hyperedges(encoded: EncodedNetwork, config: NetworkPreprocessingConfig) -> TripletTable:
-    score=score_triplets(encoded.edge_weight, encoded.support_count, encoded.site_observed, encoded.kinase_observed, encoded.kinase_ids, encoded.substrate_ids)
+    score=score_triplets(encoded.edge_weight, encoded.support_count, encoded.site_observed, encoded.kinase_observed, encoded.kinase_node_ids, encoded.substrate_node_ids)
     return TripletTable(encoded.kinase_ids, encoded.site_ids, encoded.substrate_ids, score, encoded.support_count, jnp.zeros_like(encoded.support_count, dtype=jnp.uint32))
 
 def prune_triplets(triplets: TripletTable, encoded: EncodedNetwork, config: NetworkPreprocessingConfig) -> TripletTable:
-    flags=pruning_flags(triplets.score, triplets.support_count, encoded.site_observed, encoded.kinase_observed, triplets.kinase_ids, triplets.substrate_ids, float(max(config.discovery_threshold, config.min_triplet_score)), int(config.min_support_count), bool(config.prune_self_loops), bool(config.prune_missing_observations))
+    flags=pruning_flags(triplets.score, triplets.support_count, encoded.site_observed, encoded.kinase_observed, encoded.kinase_node_ids, encoded.substrate_node_ids, float(max(config.discovery_threshold, config.min_triplet_score)), int(config.min_support_count), bool(config.prune_self_loops), bool(config.prune_missing_observations))
     keep=flags==0
     if config.max_triplets is not None and int(keep.sum())>config.max_triplets:
         kept_idx=jnp.where(keep, size=triplets.score.size, fill_value=-1)[0]

--- a/network_preprocessing/api.py
+++ b/network_preprocessing/api.py
@@ -26,9 +26,22 @@ def build_sparse_theta(triplets: TripletTable, shape: tuple[int,int,int]) -> Spa
     idx,val=sparse_indices_values(triplets.kinase_ids, triplets.site_ids, triplets.substrate_ids, triplets.score)
     return SparseThetaTensor(idx,val,shape)
 
-def detect_motifs(triplets: TripletTable, config: NetworkPreprocessingConfig) -> MotifTable:
+def _common_node_edges(triplets: TripletTable, encoded: EncodedNetwork) -> tuple[list[int], list[int], list[float], tuple[str, ...]]:
+    """Map motif edges from independent kinase/substrate IDs into one protein namespace."""
+    node_labels = tuple(sorted(set(encoded.kinase_labels) | set(encoded.substrate_labels)))
+    node_id = {label: i for i, label in enumerate(node_labels)}
+    src = [node_id[encoded.kinase_labels[int(k)]] for k in jnp.asarray(triplets.kinase_ids)]
+    dst = [node_id[encoded.substrate_labels[int(s)]] for s in jnp.asarray(triplets.substrate_ids)]
+    score = list(map(float, jnp.asarray(triplets.score)))
+    return src, dst, score, node_labels
+
+def detect_motifs(triplets: TripletTable, config: NetworkPreprocessingConfig, encoded: EncodedNetwork | None = None) -> MotifTable:
     # bounded host orchestration, core edge testing array based; no dense n^3 enumeration
-    src=list(map(int, jnp.asarray(triplets.kinase_ids))); dst=list(map(int, jnp.asarray(triplets.substrate_ids))); sc=list(map(float, jnp.asarray(triplets.score)))
+    if encoded is None:
+        src=list(map(int, jnp.asarray(triplets.kinase_ids))); dst=list(map(int, jnp.asarray(triplets.substrate_ids))); node_labels=()
+    else:
+        src,dst,_,node_labels=_common_node_edges(triplets, encoded)
+    sc=list(map(float, jnp.asarray(triplets.score)))
     edge={(a,b):s for a,b,s in zip(src,dst,sc) if a!=b}; rows=[]
     for (a,b),sab in edge.items():
         for (bb,c),sbc in edge.items():
@@ -38,9 +51,9 @@ def detect_motifs(triplets: TripletTable, config: NetworkPreprocessingConfig) ->
                 if len(rows)>=config.max_motifs: break
         if len(rows)>=config.max_motifs: break
     if not rows:
-        return MotifTable(jnp.empty(0,jnp.int16),jnp.empty(0,jnp.int32),jnp.empty(0,jnp.int32),jnp.empty(0,jnp.int32),jnp.empty(0,jnp.uint8),jnp.empty(0,jnp.float64))
+        return MotifTable(jnp.empty(0,jnp.int16),jnp.empty(0,jnp.int32),jnp.empty(0,jnp.int32),jnp.empty(0,jnp.int32),jnp.empty(0,jnp.uint8),jnp.empty(0,jnp.float64),node_labels)
     arr=jnp.asarray(rows)
-    return MotifTable(arr[:,0].astype(jnp.int16),arr[:,1].astype(jnp.int32),arr[:,2].astype(jnp.int32),arr[:,3].astype(jnp.int32),arr[:,4].astype(jnp.uint8),arr[:,5].astype(jnp.float64))
+    return MotifTable(arr[:,0].astype(jnp.int16),arr[:,1].astype(jnp.int32),arr[:,2].astype(jnp.int32),arr[:,3].astype(jnp.int32),arr[:,4].astype(jnp.uint8),arr[:,5].astype(jnp.float64),node_labels)
 
 def preprocess_identifiability(theta: SparseThetaTensor, config: NetworkPreprocessingConfig) -> IdentifiabilityDiagnostics:
     from .jax_kernels import identifiability_kernel
@@ -53,7 +66,7 @@ def preprocess_network(kinase_network: pd.DataFrame, *, phospho_observations=Non
     encoded, grouped=encode_kinase_network(kinase_network, phospho_observations, protein_observations)
     discovered=discover_hyperedges(encoded, config); pruned=prune_triplets(discovered, encoded, config)
     theta=build_sparse_theta(pruned, (len(encoded.kinase_labels), len(encoded.site_labels), len(encoded.substrate_labels)))
-    motifs=detect_motifs(pruned, config) if config.enable_motifs else None
+    motifs=detect_motifs(pruned, config, encoded) if config.enable_motifs else None
     ident=preprocess_identifiability(theta, config) if config.enable_identifiability else None
     summary={"n_discovered": int(discovered.score.size), "n_retained": int(pruned.score.size), "n_pruned": int(discovered.score.size-pruned.score.size), "n_motifs": int(0 if motifs is None else motifs.score.size), "tensor_nnz": int(theta.values.size)}
     res=NetworkPreprocessingResult(encoded, discovered, pruned, theta, motifs, ident, summary)

--- a/network_preprocessing/api.py
+++ b/network_preprocessing/api.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+from pathlib import Path
+import logging
+import jax
+jax.config.update("jax_enable_x64", True)
+import jax.numpy as jnp
+import pandas as pd
+from .dataclasses import *
+from .io_adapters import encode_kinase_network
+from .jax_kernels import score_triplets, pruning_flags, sparse_indices_values
+
+def discover_hyperedges(encoded: EncodedNetwork, config: NetworkPreprocessingConfig) -> TripletTable:
+    score=score_triplets(encoded.edge_weight, encoded.support_count, encoded.site_observed, encoded.kinase_observed, encoded.kinase_ids, encoded.substrate_ids)
+    return TripletTable(encoded.kinase_ids, encoded.site_ids, encoded.substrate_ids, score, encoded.support_count, jnp.zeros_like(encoded.support_count, dtype=jnp.uint32))
+
+def prune_triplets(triplets: TripletTable, encoded: EncodedNetwork, config: NetworkPreprocessingConfig) -> TripletTable:
+    flags=pruning_flags(triplets.score, triplets.support_count, encoded.site_observed, encoded.kinase_observed, triplets.kinase_ids, triplets.substrate_ids, float(config.min_triplet_score), int(config.min_support_count), bool(config.prune_self_loops), bool(config.prune_missing_observations))
+    keep=flags==0
+    if config.max_triplets is not None and int(keep.sum())>config.max_triplets:
+        kept_idx=jnp.where(keep, size=triplets.score.size, fill_value=-1)[0]
+        order=jnp.argsort(jnp.where(keep, -triplets.score, jnp.inf))[:config.max_triplets]
+        mask=jnp.zeros_like(keep).at[order].set(True); keep=keep & mask
+    return TripletTable(triplets.kinase_ids[keep], triplets.site_ids[keep], triplets.substrate_ids[keep], triplets.score[keep], triplets.support_count[keep], flags[keep])
+
+def build_sparse_theta(triplets: TripletTable, shape: tuple[int,int,int]) -> SparseThetaTensor:
+    idx,val=sparse_indices_values(triplets.kinase_ids, triplets.site_ids, triplets.substrate_ids, triplets.score)
+    return SparseThetaTensor(idx,val,shape)
+
+def detect_motifs(triplets: TripletTable, config: NetworkPreprocessingConfig) -> MotifTable:
+    # bounded host orchestration, core edge testing array based; no dense n^3 enumeration
+    src=list(map(int, jnp.asarray(triplets.kinase_ids))); dst=list(map(int, jnp.asarray(triplets.substrate_ids))); sc=list(map(float, jnp.asarray(triplets.score)))
+    edge={(a,b):s for a,b,s in zip(src,dst,sc) if a!=b}; rows=[]
+    for (a,b),sab in edge.items():
+        for (bb,c),sbc in edge.items():
+            if bb!=b or c in (a,b): continue
+            if (a,c) in edge:
+                rows.append((1,a,b,c,0b111,(sab*sbc*edge[(a,c)])**(1/3)))
+                if len(rows)>=config.max_motifs: break
+        if len(rows)>=config.max_motifs: break
+    if not rows:
+        return MotifTable(jnp.empty(0,jnp.int16),jnp.empty(0,jnp.int32),jnp.empty(0,jnp.int32),jnp.empty(0,jnp.int32),jnp.empty(0,jnp.uint8),jnp.empty(0,jnp.float64))
+    arr=jnp.asarray(rows)
+    return MotifTable(arr[:,0].astype(jnp.int16),arr[:,1].astype(jnp.int32),arr[:,2].astype(jnp.int32),arr[:,3].astype(jnp.int32),arr[:,4].astype(jnp.uint8),arr[:,5].astype(jnp.float64))
+
+def preprocess_identifiability(theta: SparseThetaTensor, config: NetworkPreprocessingConfig) -> IdentifiabilityDiagnostics:
+    from .jax_kernels import identifiability_kernel
+    retained,gid,norms,red=identifiability_kernel(theta.indices, theta.values)
+    rank=int(jnp.unique(gid, size=gid.size, fill_value=-1).size) if gid.size else 0
+    return IdentifiabilityDiagnostics(retained,gid,rank,red,norms)
+
+def preprocess_network(kinase_network: pd.DataFrame, *, phospho_observations=None, protein_observations=None, rna_observations=None, tf_network=None, config=None, output_dir=None, logger=None):
+    config=config or NetworkPreprocessingConfig(); logger=logger or logging.getLogger(__name__)
+    encoded, grouped=encode_kinase_network(kinase_network, phospho_observations, protein_observations)
+    discovered=discover_hyperedges(encoded, config); pruned=prune_triplets(discovered, encoded, config)
+    theta=build_sparse_theta(pruned, (len(encoded.kinase_labels), len(encoded.site_labels), len(encoded.substrate_labels)))
+    motifs=detect_motifs(pruned, config) if config.enable_motifs else None
+    ident=preprocess_identifiability(theta, config) if config.enable_identifiability else None
+    summary={"n_discovered": int(discovered.score.size), "n_retained": int(pruned.score.size), "n_pruned": int(discovered.score.size-pruned.score.size), "n_motifs": int(0 if motifs is None else motifs.score.size), "tensor_nnz": int(theta.values.size)}
+    res=NetworkPreprocessingResult(encoded, discovered, pruned, theta, motifs, ident, summary)
+    if output_dir is not None:
+        from .export import export_preprocessing_result
+        from .plotting import plot_preprocessing_result
+        export_preprocessing_result(res, output_dir); plot_preprocessing_result(res, output_dir)
+        logger.info("[NetworkPreprocessing] outputs saved under %s", Path(output_dir)/config.output_subdir)
+    return res
+
+def preprocess_networkmodel_frames(df_kin, df_tf, df_prot, df_pho, df_rna, *, config=None, output_dir=None, logger=None):
+    res=preprocess_network(df_kin, phospho_observations=df_pho, protein_observations=df_prot, rna_observations=df_rna, tf_network=df_tf, config=config, output_dir=output_dir, logger=logger)
+    enc=res.encoded
+    retained={(enc.kinase_labels[int(k)], enc.site_labels[int(s)].split(":",1)[0], enc.site_labels[int(s)].split(":",1)[1]) for k,s in zip(res.pruned.kinase_ids, res.pruned.site_ids)}
+    out=df_kin.copy(); mask=[(str(r.kinase).strip().upper(), str(r.protein).strip().upper(), str(r.psite).strip()) in retained for r in out.itertuples()]
+    return out.loc[mask].copy(), res

--- a/network_preprocessing/dataclasses.py
+++ b/network_preprocessing/dataclasses.py
@@ -30,7 +30,7 @@ class NetworkPreprocessingConfig:
             min_triplet_score=float(getattr(args, "network_preprocessing_min_score", 0.0)),
             discovery_threshold=float(getattr(args, "network_preprocessing_discovery_threshold", 0.0)),
             min_support_count=int(getattr(args, "network_preprocessing_min_support", 1)),
-            max_triplets=getattr(args, "network_preprocessing_max_triplets", None),
+            max_triplets=(None if getattr(args, "network_preprocessing_max_triplets", None) == 0 else getattr(args, "network_preprocessing_max_triplets", None)),
             batch_size=int(getattr(args, "network_preprocessing_batch_size", 65536)),
             enable_motifs=bool(getattr(args, "network_preprocessing_enable_motifs", True)),
             enable_identifiability=bool(getattr(args, "network_preprocessing_enable_identifiability", True)),
@@ -46,6 +46,8 @@ class NetworkPreprocessingConfig:
 class EncodedNetwork:
     kinase_ids: jax.Array
     substrate_ids: jax.Array
+    kinase_node_ids: jax.Array
+    substrate_node_ids: jax.Array
     site_ids: jax.Array
     edge_weight: jax.Array
     support_count: jax.Array

--- a/network_preprocessing/dataclasses.py
+++ b/network_preprocessing/dataclasses.py
@@ -68,6 +68,7 @@ class SparseThetaTensor:
 class MotifTable:
     motif_type: jax.Array; node_a: jax.Array; node_b: jax.Array; node_c: jax.Array
     edge_mask: jax.Array; score: jax.Array
+    node_labels: tuple[str, ...] = ()
 
 @dataclass(frozen=True)
 class IdentifiabilityDiagnostics:

--- a/network_preprocessing/dataclasses.py
+++ b/network_preprocessing/dataclasses.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+import jax
+import jax.numpy as jnp
+
+@dataclass(frozen=True)
+class NetworkPreprocessingConfig:
+    min_triplet_score: float = 0.0
+    min_support_count: int = 1
+    max_triplets: int | None = None
+    batch_size: int = 65536
+    dtype: str = "float64"
+    enable_motifs: bool = True
+    enable_identifiability: bool = True
+    prune_self_loops: bool = True
+    prune_missing_observations: bool = False
+    output_subdir: str = "network_preprocessing"
+    dense_motif_node_limit: int = 256
+    max_motifs: int = 10000
+    score_weights: Mapping[str, float] = field(default_factory=dict)
+
+    @staticmethod
+    def from_args(args: Any) -> "NetworkPreprocessingConfig":
+        return NetworkPreprocessingConfig(
+            min_triplet_score=float(getattr(args, "network_preprocessing_min_score", 0.0)),
+            min_support_count=int(getattr(args, "network_preprocessing_min_support", 1)),
+            max_triplets=getattr(args, "network_preprocessing_max_triplets", None),
+            prune_self_loops=bool(getattr(args, "network_preprocessing_prune_self_loops", True)),
+            prune_missing_observations=bool(getattr(args, "network_preprocessing_prune_missing_observations", False)),
+        )
+
+@dataclass(frozen=True)
+class EncodedNetwork:
+    kinase_ids: jax.Array
+    substrate_ids: jax.Array
+    site_ids: jax.Array
+    edge_weight: jax.Array
+    support_count: jax.Array
+    site_observed: jax.Array
+    kinase_observed: jax.Array
+    kinase_labels: tuple[str, ...]
+    substrate_labels: tuple[str, ...]
+    site_labels: tuple[str, ...]
+
+@dataclass(frozen=True)
+class TripletTable:
+    kinase_ids: jax.Array; site_ids: jax.Array; substrate_ids: jax.Array
+    score: jax.Array; support_count: jax.Array; flags: jax.Array
+
+@dataclass(frozen=True)
+class SparseThetaTensor:
+    indices: jax.Array; values: jax.Array; shape: tuple[int, int, int]
+
+@dataclass(frozen=True)
+class MotifTable:
+    motif_type: jax.Array; node_a: jax.Array; node_b: jax.Array; node_c: jax.Array
+    edge_mask: jax.Array; score: jax.Array
+
+@dataclass(frozen=True)
+class IdentifiabilityDiagnostics:
+    retained_param_mask: jax.Array; group_id: jax.Array; local_rank_estimate: int
+    redundancy_score: jax.Array; design_column_norm: jax.Array
+
+@dataclass(frozen=True)
+class NetworkPreprocessingResult:
+    encoded: EncodedNetwork; discovered: TripletTable; pruned: TripletTable
+    theta: SparseThetaTensor; motifs: MotifTable | None
+    identifiability: IdentifiabilityDiagnostics | None; summary: Mapping[str, Any]

--- a/network_preprocessing/dataclasses.py
+++ b/network_preprocessing/dataclasses.py
@@ -7,6 +7,7 @@ import jax.numpy as jnp
 @dataclass(frozen=True)
 class NetworkPreprocessingConfig:
     min_triplet_score: float = 0.0
+    discovery_threshold: float = 0.0
     min_support_count: int = 1
     max_triplets: int | None = None
     batch_size: int = 65536
@@ -16,6 +17,9 @@ class NetworkPreprocessingConfig:
     prune_self_loops: bool = True
     prune_missing_observations: bool = False
     output_subdir: str = "network_preprocessing"
+    export_sparse_tensor: bool = True
+    generate_plots: bool = True
+    export_csv: bool = True
     dense_motif_node_limit: int = 256
     max_motifs: int = 10000
     score_weights: Mapping[str, float] = field(default_factory=dict)
@@ -24,10 +28,18 @@ class NetworkPreprocessingConfig:
     def from_args(args: Any) -> "NetworkPreprocessingConfig":
         return NetworkPreprocessingConfig(
             min_triplet_score=float(getattr(args, "network_preprocessing_min_score", 0.0)),
+            discovery_threshold=float(getattr(args, "network_preprocessing_discovery_threshold", 0.0)),
             min_support_count=int(getattr(args, "network_preprocessing_min_support", 1)),
             max_triplets=getattr(args, "network_preprocessing_max_triplets", None),
+            batch_size=int(getattr(args, "network_preprocessing_batch_size", 65536)),
+            enable_motifs=bool(getattr(args, "network_preprocessing_enable_motifs", True)),
+            enable_identifiability=bool(getattr(args, "network_preprocessing_enable_identifiability", True)),
             prune_self_loops=bool(getattr(args, "network_preprocessing_prune_self_loops", True)),
             prune_missing_observations=bool(getattr(args, "network_preprocessing_prune_missing_observations", False)),
+            output_subdir=str(getattr(args, "network_preprocessing_output_subdir", "network_preprocessing")),
+            export_sparse_tensor=bool(getattr(args, "network_preprocessing_export_sparse_tensor", True)),
+            generate_plots=bool(getattr(args, "network_preprocessing_generate_plots", True)),
+            export_csv=bool(getattr(args, "network_preprocessing_export_csv", True)),
         )
 
 @dataclass(frozen=True)

--- a/network_preprocessing/export.py
+++ b/network_preprocessing/export.py
@@ -13,17 +13,20 @@ def _base(output_dir, subdir="network_preprocessing"):
     root.mkdir(parents=True, exist_ok=True)
     return root
 
-def export_preprocessing_result(result, output_dir, *, labels=None):
-    root=_base(output_dir); enc=result.encoded; paths={}
+def export_preprocessing_result(result, output_dir, *, labels=None, output_subdir="network_preprocessing", include_csv=True, include_sparse_tensor=True):
+    root=_base(output_dir, output_subdir); enc=result.encoded; paths={}
     def trip_df(t):
         return pd.DataFrame({"kinase_id":np.asarray(t.kinase_ids),"site_id":np.asarray(t.site_ids),"substrate_id":np.asarray(t.substrate_ids),"kinase":[enc.kinase_labels[int(i)] for i in np.asarray(t.kinase_ids)],"site":[enc.site_labels[int(i)] for i in np.asarray(t.site_ids)],"substrate":[enc.substrate_labels[int(i)] for i in np.asarray(t.substrate_ids)],"score":np.asarray(t.score),"support_count":np.asarray(t.support_count),"flags":np.asarray(t.flags)})
-    for name,t in [("discovered_hyperedges",result.discovered),("retained_triplets",result.pruned)]:
-        p=root/f"{name}.csv"; trip_df(t).to_csv(p,index=False); paths[name]=p
-    p=root/"sparse_theta_indices_values.csv"; trip_df(result.pruned).assign(theta_value=np.asarray(result.theta.values)).to_csv(p,index=False); paths["theta_csv"]=p
-    p=root/"sparse_theta.npz"; np.savez_compressed(p, indices=np.asarray(result.theta.indices), values=np.asarray(result.theta.values), shape=np.asarray(result.theta.shape)); paths["theta_npz"]=p
-    if result.motifs is not None:
+    if include_csv:
+        for name,t in [("discovered_hyperedges",result.discovered),("retained_triplets",result.pruned)]:
+            p=root/f"{name}.csv"; trip_df(t).to_csv(p,index=False); paths[name]=p
+    if include_sparse_tensor:
+        p=root/"sparse_theta_indices_values.csv"; trip_df(result.pruned).assign(theta_value=np.asarray(result.theta.values)).to_csv(p,index=False); paths["theta_csv"]=p
+        p=root/"sparse_theta.npz"; np.savez_compressed(p, indices=np.asarray(result.theta.indices), values=np.asarray(result.theta.values), shape=np.asarray(result.theta.shape)); paths["theta_npz"]=p
+    if include_csv and result.motifs is not None:
         m=result.motifs; p=root/"motif_table.csv"; pd.DataFrame({"motif_type":np.asarray(m.motif_type),"node_a":np.asarray(m.node_a),"node_b":np.asarray(m.node_b),"node_c":np.asarray(m.node_c),"edge_mask":np.asarray(m.edge_mask),"score":np.asarray(m.score)}).to_csv(p,index=False); paths["motifs"]=p
-    if result.identifiability is not None:
+    if include_csv and result.identifiability is not None:
         d=result.identifiability; p=root/"identifiability_diagnostics.csv"; pd.DataFrame({"retained_param_mask":np.asarray(d.retained_param_mask),"group_id":np.asarray(d.group_id),"redundancy_score":np.asarray(d.redundancy_score),"design_column_norm":np.asarray(d.design_column_norm)}).to_csv(p,index=False); paths["identifiability"]=p
-    p=root/"summary_statistics.json"; p.write_text(json.dumps(result.summary,indent=2,sort_keys=True)+"\n"); paths["summary"]=p
+    if include_csv:
+        p=root/"summary_statistics.json"; p.write_text(json.dumps(result.summary,indent=2,sort_keys=True)+"\n"); paths["summary"]=p
     return paths

--- a/network_preprocessing/export.py
+++ b/network_preprocessing/export.py
@@ -24,7 +24,15 @@ def export_preprocessing_result(result, output_dir, *, labels=None, output_subdi
         p=root/"sparse_theta_indices_values.csv"; trip_df(result.pruned).assign(theta_value=np.asarray(result.theta.values)).to_csv(p,index=False); paths["theta_csv"]=p
         p=root/"sparse_theta.npz"; np.savez_compressed(p, indices=np.asarray(result.theta.indices), values=np.asarray(result.theta.values), shape=np.asarray(result.theta.shape)); paths["theta_npz"]=p
     if include_csv and result.motifs is not None:
-        m=result.motifs; p=root/"motif_table.csv"; pd.DataFrame({"motif_type":np.asarray(m.motif_type),"node_a":np.asarray(m.node_a),"node_b":np.asarray(m.node_b),"node_c":np.asarray(m.node_c),"edge_mask":np.asarray(m.edge_mask),"score":np.asarray(m.score)}).to_csv(p,index=False); paths["motifs"]=p
+        m=result.motifs; p=root/"motif_table.csv"
+        motif_data={"motif_type":np.asarray(m.motif_type),"node_a":np.asarray(m.node_a),"node_b":np.asarray(m.node_b),"node_c":np.asarray(m.node_c),"edge_mask":np.asarray(m.edge_mask),"score":np.asarray(m.score)}
+        if getattr(m, "node_labels", ()):
+            motif_data.update({
+                "node_a_label":[m.node_labels[int(i)] for i in np.asarray(m.node_a)],
+                "node_b_label":[m.node_labels[int(i)] for i in np.asarray(m.node_b)],
+                "node_c_label":[m.node_labels[int(i)] for i in np.asarray(m.node_c)],
+            })
+        pd.DataFrame(motif_data).to_csv(p,index=False); paths["motifs"]=p
     if include_csv and result.identifiability is not None:
         d=result.identifiability; p=root/"identifiability_diagnostics.csv"; pd.DataFrame({"retained_param_mask":np.asarray(d.retained_param_mask),"group_id":np.asarray(d.group_id),"redundancy_score":np.asarray(d.redundancy_score),"design_column_norm":np.asarray(d.design_column_norm)}).to_csv(p,index=False); paths["identifiability"]=p
     if include_csv:

--- a/network_preprocessing/export.py
+++ b/network_preprocessing/export.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+from pathlib import Path
+import json
+import numpy as np
+import pandas as pd
+
+def _base(output_dir, subdir="network_preprocessing"):
+    try:
+        from common.results import ensure_result_dir
+        paths=ensure_result_dir(output_dir); root=paths["tables"] / subdir
+    except Exception:
+        root=Path(output_dir)/subdir
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+def export_preprocessing_result(result, output_dir, *, labels=None):
+    root=_base(output_dir); enc=result.encoded; paths={}
+    def trip_df(t):
+        return pd.DataFrame({"kinase_id":np.asarray(t.kinase_ids),"site_id":np.asarray(t.site_ids),"substrate_id":np.asarray(t.substrate_ids),"kinase":[enc.kinase_labels[int(i)] for i in np.asarray(t.kinase_ids)],"site":[enc.site_labels[int(i)] for i in np.asarray(t.site_ids)],"substrate":[enc.substrate_labels[int(i)] for i in np.asarray(t.substrate_ids)],"score":np.asarray(t.score),"support_count":np.asarray(t.support_count),"flags":np.asarray(t.flags)})
+    for name,t in [("discovered_hyperedges",result.discovered),("retained_triplets",result.pruned)]:
+        p=root/f"{name}.csv"; trip_df(t).to_csv(p,index=False); paths[name]=p
+    p=root/"sparse_theta_indices_values.csv"; trip_df(result.pruned).assign(theta_value=np.asarray(result.theta.values)).to_csv(p,index=False); paths["theta_csv"]=p
+    p=root/"sparse_theta.npz"; np.savez_compressed(p, indices=np.asarray(result.theta.indices), values=np.asarray(result.theta.values), shape=np.asarray(result.theta.shape)); paths["theta_npz"]=p
+    if result.motifs is not None:
+        m=result.motifs; p=root/"motif_table.csv"; pd.DataFrame({"motif_type":np.asarray(m.motif_type),"node_a":np.asarray(m.node_a),"node_b":np.asarray(m.node_b),"node_c":np.asarray(m.node_c),"edge_mask":np.asarray(m.edge_mask),"score":np.asarray(m.score)}).to_csv(p,index=False); paths["motifs"]=p
+    if result.identifiability is not None:
+        d=result.identifiability; p=root/"identifiability_diagnostics.csv"; pd.DataFrame({"retained_param_mask":np.asarray(d.retained_param_mask),"group_id":np.asarray(d.group_id),"redundancy_score":np.asarray(d.redundancy_score),"design_column_norm":np.asarray(d.design_column_norm)}).to_csv(p,index=False); paths["identifiability"]=p
+    p=root/"summary_statistics.json"; p.write_text(json.dumps(result.summary,indent=2,sort_keys=True)+"\n"); paths["summary"]=p
+    return paths

--- a/network_preprocessing/export.py
+++ b/network_preprocessing/export.py
@@ -16,7 +16,8 @@ def _base(output_dir, subdir="network_preprocessing"):
 def export_preprocessing_result(result, output_dir, *, labels=None, output_subdir="network_preprocessing", include_csv=True, include_sparse_tensor=True):
     root=_base(output_dir, output_subdir); enc=result.encoded; paths={}
     def trip_df(t):
-        return pd.DataFrame({"kinase_id":np.asarray(t.kinase_ids),"site_id":np.asarray(t.site_ids),"substrate_id":np.asarray(t.substrate_ids),"kinase":[enc.kinase_labels[int(i)] for i in np.asarray(t.kinase_ids)],"site":[enc.site_labels[int(i)] for i in np.asarray(t.site_ids)],"substrate":[enc.substrate_labels[int(i)] for i in np.asarray(t.substrate_ids)],"score":np.asarray(t.score),"support_count":np.asarray(t.support_count),"flags":np.asarray(t.flags)})
+        alpha_by_key={(int(k),int(s),int(sub)):float(a) for k,s,sub,a in zip(enc.kinase_ids,enc.site_ids,enc.substrate_ids,enc.edge_weight)}
+        return pd.DataFrame({"kinase_id":np.asarray(t.kinase_ids),"site_id":np.asarray(t.site_ids),"substrate_id":np.asarray(t.substrate_ids),"kinase":[enc.kinase_labels[int(i)] for i in np.asarray(t.kinase_ids)],"site":[enc.site_labels[int(i)] for i in np.asarray(t.site_ids)],"substrate":[enc.substrate_labels[int(i)] for i in np.asarray(t.substrate_ids)],"alpha":[alpha_by_key[(int(k),int(s),int(sub))] for k,s,sub in zip(np.asarray(t.kinase_ids),np.asarray(t.site_ids),np.asarray(t.substrate_ids))],"score":np.asarray(t.score),"support_count":np.asarray(t.support_count),"flags":np.asarray(t.flags)})
     if include_csv:
         for name,t in [("discovered_hyperedges",result.discovered),("retained_triplets",result.pruned)]:
             p=root/f"{name}.csv"; trip_df(t).to_csv(p,index=False); paths[name]=p

--- a/network_preprocessing/io_adapters.py
+++ b/network_preprocessing/io_adapters.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+import pandas as pd
+import jax.numpy as jnp
+from .dataclasses import EncodedNetwork
+
+def _labels(vals): return tuple(sorted({str(v).strip().upper() for v in vals if str(v).strip()}))
+def encode_kinase_network(df_kin: pd.DataFrame, phospho_observations=None, protein_observations=None) -> tuple[EncodedNetwork, pd.DataFrame]:
+    req={"protein","psite","kinase"}; miss=req-set(df_kin.columns)
+    if miss: raise ValueError(f"kinase network missing columns: {sorted(miss)}")
+    df=df_kin.copy()
+    df["protein"]=df["protein"].astype(str).str.strip().str.upper(); df["kinase"]=df["kinase"].astype(str).str.strip().str.upper(); df["psite"]=df["psite"].astype(str).str.strip()
+    if "alpha" not in df: df["alpha"]=1.0
+    g=df.groupby(["kinase","protein","psite"], as_index=False).agg(alpha=("alpha","max"), support_count=("alpha","size"))
+    kin=_labels(g["kinase"]); sub=_labels(g["protein"]); sites=tuple(sorted({f"{p}:{s}" for p,s in zip(g.protein,g.psite)}))
+    km={v:i for i,v in enumerate(kin)}; sm={v:i for i,v in enumerate(sub)}; stm={v:i for i,v in enumerate(sites)}
+    obs_sites=set(); obs_kin=set()
+    if phospho_observations is not None and not phospho_observations.empty:
+        po=phospho_observations.copy(); po["protein"]=po["protein"].astype(str).str.strip().str.upper(); po["psite"]=po["psite"].astype(str).str.strip()
+        obs_sites={f"{p}:{s}" for p,s in zip(po.protein, po.psite)}
+    if protein_observations is not None and not protein_observations.empty:
+        obs_kin={str(x).strip().upper() for x in protein_observations["protein"].unique()}
+    enc=EncodedNetwork(
+        kinase_ids=jnp.asarray([km[x] for x in g.kinase], jnp.int32), substrate_ids=jnp.asarray([sm[x] for x in g.protein], jnp.int32),
+        site_ids=jnp.asarray([stm[f"{p}:{s}"] for p,s in zip(g.protein,g.psite)], jnp.int32), edge_weight=jnp.asarray(g.alpha.to_numpy(), jnp.float64),
+        support_count=jnp.asarray(g.support_count.to_numpy(), jnp.int32), site_observed=jnp.asarray([f"{p}:{s}" in obs_sites for p,s in zip(g.protein,g.psite)], bool),
+        kinase_observed=jnp.asarray([k in obs_kin for k in g.kinase], bool), kinase_labels=kin, substrate_labels=sub, site_labels=sites)
+    return enc, g

--- a/network_preprocessing/io_adapters.py
+++ b/network_preprocessing/io_adapters.py
@@ -13,6 +13,7 @@ def encode_kinase_network(df_kin: pd.DataFrame, phospho_observations=None, prote
     g=df.groupby(["kinase","protein","psite"], as_index=False).agg(alpha=("alpha","max"), support_count=("alpha","size"))
     kin=_labels(g["kinase"]); sub=_labels(g["protein"]); sites=tuple(sorted({f"{p}:{s}" for p,s in zip(g.protein,g.psite)}))
     km={v:i for i,v in enumerate(kin)}; sm={v:i for i,v in enumerate(sub)}; stm={v:i for i,v in enumerate(sites)}
+    node_labels=tuple(sorted(set(kin) | set(sub))); nm={v:i for i,v in enumerate(node_labels)}
     obs_sites=set(); obs_kin=set()
     if phospho_observations is not None and not phospho_observations.empty:
         po=phospho_observations.copy(); po["protein"]=po["protein"].astype(str).str.strip().str.upper(); po["psite"]=po["psite"].astype(str).str.strip()
@@ -21,6 +22,7 @@ def encode_kinase_network(df_kin: pd.DataFrame, phospho_observations=None, prote
         obs_kin={str(x).strip().upper() for x in protein_observations["protein"].unique()}
     enc=EncodedNetwork(
         kinase_ids=jnp.asarray([km[x] for x in g.kinase], jnp.int32), substrate_ids=jnp.asarray([sm[x] for x in g.protein], jnp.int32),
+        kinase_node_ids=jnp.asarray([nm[x] for x in g.kinase], jnp.int32), substrate_node_ids=jnp.asarray([nm[x] for x in g.protein], jnp.int32),
         site_ids=jnp.asarray([stm[f"{p}:{s}"] for p,s in zip(g.protein,g.psite)], jnp.int32), edge_weight=jnp.asarray(g.alpha.to_numpy(), jnp.float64),
         support_count=jnp.asarray(g.support_count.to_numpy(), jnp.int32), site_observed=jnp.asarray([f"{p}:{s}" in obs_sites for p,s in zip(g.protein,g.psite)], bool),
         kinase_observed=jnp.asarray([k in obs_kin for k in g.kinase], bool), kinase_labels=kin, substrate_labels=sub, site_labels=sites)

--- a/network_preprocessing/jax_kernels.py
+++ b/network_preprocessing/jax_kernels.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+import jax
+jax.config.update("jax_enable_x64", True)
+import jax.numpy as jnp
+
+FLAG_LOW_SCORE = jnp.uint32(1 << 0)
+FLAG_LOW_SUPPORT = jnp.uint32(1 << 1)
+FLAG_SELF_LOOP = jnp.uint32(1 << 2)
+FLAG_MISSING_SITE_OBS = jnp.uint32(1 << 3)
+FLAG_MISSING_KINASE_OBS = jnp.uint32(1 << 4)
+FLAG_OVER_BUDGET = jnp.uint32(1 << 5)
+
+@jax.jit
+def score_triplets(edge_weight, support_count, site_observed, kinase_observed, kinase_ids, substrate_ids):
+    score = jnp.log1p(edge_weight.astype(jnp.float64)) + 0.5*jnp.log1p(support_count.astype(jnp.float64))
+    score = score + 0.25*site_observed.astype(jnp.float64) + 0.25*kinase_observed.astype(jnp.float64)
+    score = score - 0.5*(kinase_ids == substrate_ids).astype(jnp.float64)
+    return score.astype(jnp.float64)
+
+@jax.jit
+def pruning_flags(score, support_count, site_observed, kinase_observed, kinase_ids, substrate_ids,
+                  min_score, min_support, prune_self_loops, prune_missing_observations):
+    flags = jnp.zeros(score.shape, dtype=jnp.uint32)
+    flags = jnp.where(score < min_score, flags | FLAG_LOW_SCORE, flags)
+    flags = jnp.where(support_count < min_support, flags | FLAG_LOW_SUPPORT, flags)
+    flags = jnp.where((kinase_ids == substrate_ids) & prune_self_loops, flags | FLAG_SELF_LOOP, flags)
+    flags = jnp.where((~site_observed) & prune_missing_observations, flags | FLAG_MISSING_SITE_OBS, flags)
+    flags = jnp.where((~kinase_observed) & prune_missing_observations, flags | FLAG_MISSING_KINASE_OBS, flags)
+    return flags
+
+@jax.jit
+def sparse_indices_values(kinase_ids, site_ids, substrate_ids, score):
+    return jnp.stack([kinase_ids, site_ids, substrate_ids], axis=1).astype(jnp.int32), score.astype(jnp.float64)
+
+@jax.jit
+def identifiability_kernel(indices, values):
+    norms = jnp.abs(values).astype(jnp.float64)
+    retained = norms > jnp.finfo(jnp.float64).eps
+    keys = indices[:,0]*jnp.int32(1000003) + indices[:,1]*jnp.int32(1009) + indices[:,2]
+    order = jnp.argsort(keys)
+    sorted_keys = keys[order]
+    new_group = jnp.concatenate([jnp.array([True]), sorted_keys[1:] != sorted_keys[:-1]])
+    gid_sorted = jnp.cumsum(new_group.astype(jnp.int32)) - 1
+    gid = jnp.empty_like(gid_sorted).at[order].set(gid_sorted)
+    redundancy = 1.0 - retained.astype(jnp.float64)
+    return retained, gid, norms, redundancy

--- a/network_preprocessing/jax_kernels.py
+++ b/network_preprocessing/jax_kernels.py
@@ -36,10 +36,13 @@ def sparse_indices_values(kinase_ids, site_ids, substrate_ids, score):
 def identifiability_kernel(indices, values):
     norms = jnp.abs(values).astype(jnp.float64)
     retained = norms > jnp.finfo(jnp.float64).eps
-    keys = indices[:,0]*jnp.int32(1000003) + indices[:,1]*jnp.int32(1009) + indices[:,2]
-    order = jnp.argsort(keys)
-    sorted_keys = keys[order]
-    new_group = jnp.concatenate([jnp.array([True]), sorted_keys[1:] != sorted_keys[:-1]])
+    idx64 = indices.astype(jnp.int64)
+    order = jnp.lexsort((idx64[:, 2], idx64[:, 1], idx64[:, 0]))
+    sorted_idx = idx64[order]
+    new_group = jnp.concatenate([
+        jnp.array([True]),
+        jnp.any(sorted_idx[1:] != sorted_idx[:-1], axis=1),
+    ])
     gid_sorted = jnp.cumsum(new_group.astype(jnp.int32)) - 1
     gid = jnp.empty_like(gid_sorted).at[order].set(gid_sorted)
     redundancy = 1.0 - retained.astype(jnp.float64)

--- a/network_preprocessing/plotting.py
+++ b/network_preprocessing/plotting.py
@@ -10,9 +10,9 @@ def _plot_dir(output_dir, subdir="network_preprocessing"):
         root=Path(output_dir)/subdir/"plots"
     root.mkdir(parents=True, exist_ok=True); return root
 
-def plot_preprocessing_result(result, output_dir, *, style="paper"):
+def plot_preprocessing_result(result, output_dir, *, style="paper", output_subdir="network_preprocessing"):
     import matplotlib.pyplot as plt
-    root=_plot_dir(output_dir); paths={}
+    root=_plot_dir(output_dir, output_subdir); paths={}
     scores=np.asarray(result.discovered.score)
     fig,ax=plt.subplots(); ax.hist(scores, bins=min(30, max(1, len(scores)))); ax.set_title("Hyperedge score distribution"); ax.set_xlabel("score"); ax.set_ylabel("count"); p=root/"hyperedge_score_distribution.png"; fig.savefig(p,dpi=200,bbox_inches="tight"); plt.close(fig); paths["scores"]=p
     fig,ax=plt.subplots(); ax.bar(["retained","removed"],[result.summary["n_retained"], result.summary["n_pruned"]]); ax.set_title("Retained vs removed triplets"); p=root/"retained_vs_removed_triplets.png"; fig.savefig(p,dpi=200,bbox_inches="tight"); plt.close(fig); paths["retained_removed"]=p

--- a/network_preprocessing/plotting.py
+++ b/network_preprocessing/plotting.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+from pathlib import Path
+import numpy as np
+
+def _plot_dir(output_dir, subdir="network_preprocessing"):
+    try:
+        from common.results import ensure_result_dir
+        root=ensure_result_dir(output_dir)["plots"] / subdir
+    except Exception:
+        root=Path(output_dir)/subdir/"plots"
+    root.mkdir(parents=True, exist_ok=True); return root
+
+def plot_preprocessing_result(result, output_dir, *, style="paper"):
+    import matplotlib.pyplot as plt
+    root=_plot_dir(output_dir); paths={}
+    scores=np.asarray(result.discovered.score)
+    fig,ax=plt.subplots(); ax.hist(scores, bins=min(30, max(1, len(scores)))); ax.set_title("Hyperedge score distribution"); ax.set_xlabel("score"); ax.set_ylabel("count"); p=root/"hyperedge_score_distribution.png"; fig.savefig(p,dpi=200,bbox_inches="tight"); plt.close(fig); paths["scores"]=p
+    fig,ax=plt.subplots(); ax.bar(["retained","removed"],[result.summary["n_retained"], result.summary["n_pruned"]]); ax.set_title("Retained vs removed triplets"); p=root/"retained_vs_removed_triplets.png"; fig.savefig(p,dpi=200,bbox_inches="tight"); plt.close(fig); paths["retained_removed"]=p
+    deg=np.bincount(np.asarray(result.pruned.kinase_ids), minlength=len(result.encoded.kinase_labels)) if result.pruned.kinase_ids.size else np.array([])
+    fig,ax=plt.subplots(); ax.hist(deg, bins=min(20,max(1,len(deg)))); ax.set_title("Kinase degree distribution"); p=root/"degree_distribution.png"; fig.savefig(p,dpi=200,bbox_inches="tight"); plt.close(fig); paths["degree"]=p
+    fig,ax=plt.subplots(); ax.bar(["nnz","dense size"],[result.summary["tensor_nnz"], np.prod(result.theta.shape)]); ax.set_title("Sparse tensor summary"); p=root/"sparse_tensor_summary.png"; fig.savefig(p,dpi=200,bbox_inches="tight"); plt.close(fig); paths["tensor"]=p
+    fig,ax=plt.subplots(); ax.bar(["motifs"],[result.summary["n_motifs"]]); ax.set_title("Motif count summary"); p=root/"motif_count_summary.png"; fig.savefig(p,dpi=200,bbox_inches="tight"); plt.close(fig); paths["motifs"]=p
+    if result.identifiability is not None:
+        fig,ax=plt.subplots(); ax.hist(np.asarray(result.identifiability.redundancy_score), bins=10); ax.set_title("Identifiability diagnostics"); p=root/"identifiability_diagnostics.png"; fig.savefig(p,dpi=200,bbox_inches="tight"); plt.close(fig); paths["identifiability"]=p
+    return paths

--- a/networkmodel/PosteriorObjective.py
+++ b/networkmodel/PosteriorObjective.py
@@ -24,6 +24,7 @@ os.environ.setdefault(
 )
 
 import numpy as np
+import pandas as pd
 
 from networkmodel.BuildMatrix import build_W_parallel, build_tf_matrix
 from networkmodel.OptimizationProblem import GlobalODEScalarObjective, build_weight_functions
@@ -141,6 +142,18 @@ def _prepare_tf_model(df_tf, df_kin, df_prot, df_rna, df_pho, kin_beta_map, tf_b
     return df_tf_model, idx
 
 
+def _load_data_for_posterior_context(args, cfg: dict):
+    """Load worker data, replacing df_kin with persisted preprocessed network when present."""
+    df_kin, df_tf, df_prot, df_pho, df_rna, kin_beta_map, tf_beta_map = load_data(args)
+    preprocessed_path = cfg.get("preprocessed_kinase_net")
+    if preprocessed_path:
+        path = Path(preprocessed_path)
+        if not path.is_file():
+            raise FileNotFoundError(f"preprocessed kinase network not found: {path}")
+        df_kin = pd.read_csv(path)
+    return df_kin, df_tf, df_prot, df_pho, df_rna, kin_beta_map, tf_beta_map
+
+
 def build_networkmodel_posterior_context(run_config_path: str | Path, chain_output_dir: str | Path) -> InferenceContext:
     """Rebuild an InferenceContext from saved posterior run config.
 
@@ -183,7 +196,7 @@ def build_networkmodel_posterior_context(run_config_path: str | Path, chain_outp
         solver="jaxopt",
     )
 
-    df_kin, df_tf, df_prot, df_pho, df_rna, kin_beta_map, tf_beta_map = load_data(args)
+    df_kin, df_tf, df_prot, df_pho, df_rna, kin_beta_map, tf_beta_map = _load_data_for_posterior_context(args, cfg)
 
     if args.normalize_fc_steady:
         df_prot = normalize_fc_to_t0(df_prot)
@@ -368,6 +381,10 @@ def write_posterior_payload(
         },
         "tol": float(getattr(ctx, "tol", 1e-6)),
     }
+
+    preprocessed_kinase_net = getattr(runner_args, "preprocessed_kinase_net", "")
+    if preprocessed_kinase_net:
+        run_config["preprocessed_kinase_net"] = str(preprocessed_kinase_net)
 
     run_config_path = payload_dir / "posterior_run_config.json"
     with open(run_config_path, "w") as f:

--- a/networkmodel/config.py
+++ b/networkmodel/config.py
@@ -144,3 +144,27 @@ SENSITIVITY_METRIC = getattr(cfg, "sensitivity_metric", "total_signal")
 
 # AVAILABLE_MODELS: tuple[str, ...]; default empty tuple; controls logged model metadata.
 AVAILABLE_MODELS = getattr(cfg, "available_models", ())
+
+
+# ENABLE_HYPEREDGE_PREPROCESSING: bool; default False; enables optional pure-JAX hyperedge/network preprocessing before model construction.
+ENABLE_HYPEREDGE_PREPROCESSING = _as_bool(getattr(cfg, "enable_hyperedge_preprocessing", False))
+# HYPEREDGE_PREPROCESSING_OUTPUT_SUBDIR: str; output subdirectory for preprocessing tables/plots under standard result folders.
+HYPEREDGE_PREPROCESSING_OUTPUT_SUBDIR = str(getattr(cfg, "hyperedge_preprocessing_output_subdir", "network_preprocessing"))
+# HYPEREDGE_DISCOVERY_THRESHOLD: float; minimum score threshold used for discovered hyperedges.
+HYPEREDGE_DISCOVERY_THRESHOLD = float(getattr(cfg, "hyperedge_discovery_threshold", 0.0))
+# HYPEREDGE_PRUNING_THRESHOLD: float; minimum score threshold used when pruning retained triplets.
+HYPEREDGE_PRUNING_THRESHOLD = float(getattr(cfg, "hyperedge_pruning_threshold", 0.0))
+# HYPEREDGE_MOTIF_DETECTION: bool; controls optional motif detection during preprocessing.
+HYPEREDGE_MOTIF_DETECTION = _as_bool(getattr(cfg, "hyperedge_motif_detection", True))
+# HYPEREDGE_SPARSE_TENSOR_EXPORT: bool; controls sparse tensor CSV/NPZ export.
+HYPEREDGE_SPARSE_TENSOR_EXPORT = _as_bool(getattr(cfg, "hyperedge_sparse_tensor_export", True))
+# HYPEREDGE_IDENTIFIABILITY_PREPROCESSING: bool; controls optional identifiability diagnostics.
+HYPEREDGE_IDENTIFIABILITY_PREPROCESSING = _as_bool(getattr(cfg, "hyperedge_identifiability_preprocessing", True))
+# HYPEREDGE_MAX_TRIPLETS: int | None; optional maximum retained triplets for memory safety.
+HYPEREDGE_MAX_TRIPLETS = getattr(cfg, "hyperedge_max_triplets", None)
+# HYPEREDGE_BATCH_SIZE: int; batch size used by preprocessing kernels/adapters.
+HYPEREDGE_BATCH_SIZE = int(getattr(cfg, "hyperedge_batch_size", 65536))
+# HYPEREDGE_PLOT_GENERATION: bool; controls preprocessing diagnostic plot generation.
+HYPEREDGE_PLOT_GENERATION = _as_bool(getattr(cfg, "hyperedge_plot_generation", True))
+# HYPEREDGE_CSV_EXPORT: bool; controls preprocessing CSV/JSON table export.
+HYPEREDGE_CSV_EXPORT = _as_bool(getattr(cfg, "hyperedge_csv_export", True))

--- a/networkmodel/runner.py
+++ b/networkmodel/runner.py
@@ -164,6 +164,17 @@ def _config_defaults(config: Any, resolved_config_path: Path, supplied_conf_path
         "posterior_sampling": _as_bool(getattr(config, "posterior_sampling", False)),
         "posterior_num_warmup": int(getattr(config, "posterior_num_warmup", 20)),
         "posterior_num_samples": int(getattr(config, "posterior_num_samples", 30)),
+        "enable_hyperedge_preprocessing": _as_bool(getattr(config, "enable_hyperedge_preprocessing", False)),
+        "hyperedge_preprocessing_output_subdir": str(getattr(config, "hyperedge_preprocessing_output_subdir", "network_preprocessing")),
+        "hyperedge_discovery_threshold": float(getattr(config, "hyperedge_discovery_threshold", 0.0)),
+        "hyperedge_pruning_threshold": float(getattr(config, "hyperedge_pruning_threshold", 0.0)),
+        "hyperedge_motif_detection": _as_bool(getattr(config, "hyperedge_motif_detection", True)),
+        "hyperedge_sparse_tensor_export": _as_bool(getattr(config, "hyperedge_sparse_tensor_export", True)),
+        "hyperedge_identifiability_preprocessing": _as_bool(getattr(config, "hyperedge_identifiability_preprocessing", True)),
+        "hyperedge_max_triplets": getattr(config, "hyperedge_max_triplets", None),
+        "hyperedge_batch_size": int(getattr(config, "hyperedge_batch_size", 65536)),
+        "hyperedge_plot_generation": _as_bool(getattr(config, "hyperedge_plot_generation", True)),
+        "hyperedge_csv_export": _as_bool(getattr(config, "hyperedge_csv_export", True)),
         "raw_config": config,
     }
 
@@ -198,14 +209,40 @@ def build_parser(config_defaults: dict[str, Any]) -> argparse.ArgumentParser:
                         default=config_defaults["sensitivity"])
     parser.add_argument("--solver", type=str, choices=["jaxopt", "pymoo", "optuna"], default=config_defaults["solver"],
                         help="Choice of optimization solver. Legacy pymoo/optuna values map to jaxopt.")
-    parser.add_argument("--enable-network-preprocessing", action="store_true", default=False,
+    parser.add_argument("--enable-network-preprocessing", "--enable-hyperedge-preprocessing",
+                        dest="enable_network_preprocessing", action="store_true",
+                        default=config_defaults["enable_hyperedge_preprocessing"],
                         help="Enable optional pure-JAX hyperedge/network preprocessing before model construction.")
-    parser.add_argument("--network-preprocessing-min-score", type=float, default=0.0,
+    parser.add_argument("--network-preprocessing-output-subdir", default=config_defaults["hyperedge_preprocessing_output_subdir"],
+                        help="Output subdirectory for optional network preprocessing tables and plots.")
+    parser.add_argument("--network-preprocessing-discovery-threshold", type=float,
+                        default=config_defaults["hyperedge_discovery_threshold"],
+                        help="Minimum hyperedge discovery score considered by preprocessing.")
+    parser.add_argument("--network-preprocessing-min-score", "--network-preprocessing-pruning-threshold",
+                        dest="network_preprocessing_min_score", type=float,
+                        default=config_defaults["hyperedge_pruning_threshold"],
                         help="Minimum hyperedge score retained when network preprocessing is enabled.")
     parser.add_argument("--network-preprocessing-min-support", type=int, default=1,
                         help="Minimum duplicate/source support retained when network preprocessing is enabled.")
-    parser.add_argument("--network-preprocessing-max-triplets", type=int, default=None,
+    parser.add_argument("--network-preprocessing-max-triplets", type=int, default=config_defaults["hyperedge_max_triplets"],
                         help="Optional maximum retained triplet count when network preprocessing is enabled.")
+    parser.add_argument("--network-preprocessing-batch-size", type=int, default=config_defaults["hyperedge_batch_size"],
+                        help="Batch size for optional preprocessing kernels.")
+    parser.add_argument("--disable-network-preprocessing-motifs", dest="network_preprocessing_enable_motifs",
+                        action="store_false", default=config_defaults["hyperedge_motif_detection"],
+                        help="Disable motif detection in optional network preprocessing.")
+    parser.add_argument("--disable-network-preprocessing-identifiability", dest="network_preprocessing_enable_identifiability",
+                        action="store_false", default=config_defaults["hyperedge_identifiability_preprocessing"],
+                        help="Disable identifiability preprocessing diagnostics.")
+    parser.add_argument("--disable-network-preprocessing-sparse-export", dest="network_preprocessing_export_sparse_tensor",
+                        action="store_false", default=config_defaults["hyperedge_sparse_tensor_export"],
+                        help="Disable sparse tensor CSV/NPZ export.")
+    parser.add_argument("--disable-network-preprocessing-plots", dest="network_preprocessing_generate_plots",
+                        action="store_false", default=config_defaults["hyperedge_plot_generation"],
+                        help="Disable preprocessing plot generation.")
+    parser.add_argument("--disable-network-preprocessing-csv", dest="network_preprocessing_export_csv",
+                        action="store_false", default=config_defaults["hyperedge_csv_export"],
+                        help="Disable preprocessing CSV/JSON export.")
     parser.add_argument("--network-preprocessing-prune-missing-observations", action="store_true", default=False,
                         help="Prune triplets missing phosphosite or kinase observation support when preprocessing is enabled.")
     parser.add_argument("--network-preprocessing-keep-self-loops", action="store_true", default=False,
@@ -268,6 +305,17 @@ def _runtime_metadata_extra(args: argparse.Namespace) -> dict[str, Any]:
             "n_starts": args.n_starts,
             "profile_likelihood": args.profile_likelihood,
             "posterior_sampling": args.posterior_sampling,
+            "enable_hyperedge_preprocessing": args.enable_network_preprocessing,
+            "hyperedge_preprocessing_output_subdir": args.network_preprocessing_output_subdir,
+            "hyperedge_discovery_threshold": args.network_preprocessing_discovery_threshold,
+            "hyperedge_pruning_threshold": args.network_preprocessing_min_score,
+            "hyperedge_motif_detection": args.network_preprocessing_enable_motifs,
+            "hyperedge_sparse_tensor_export": args.network_preprocessing_export_sparse_tensor,
+            "hyperedge_identifiability_preprocessing": args.network_preprocessing_enable_identifiability,
+            "hyperedge_max_triplets": args.network_preprocessing_max_triplets,
+            "hyperedge_batch_size": args.network_preprocessing_batch_size,
+            "hyperedge_plot_generation": args.network_preprocessing_generate_plots,
+            "hyperedge_csv_export": args.network_preprocessing_export_csv,
         },
     }
 
@@ -437,10 +485,18 @@ def main():
         if getattr(args, "network_preprocessing_keep_self_loops", False):
             prep_config = NetworkPreprocessingConfig(
                 min_triplet_score=prep_config.min_triplet_score,
+                discovery_threshold=prep_config.discovery_threshold,
                 min_support_count=prep_config.min_support_count,
                 max_triplets=prep_config.max_triplets,
+                batch_size=prep_config.batch_size,
+                enable_motifs=prep_config.enable_motifs,
+                enable_identifiability=prep_config.enable_identifiability,
                 prune_self_loops=False,
                 prune_missing_observations=prep_config.prune_missing_observations,
+                output_subdir=prep_config.output_subdir,
+                export_sparse_tensor=prep_config.export_sparse_tensor,
+                generate_plots=prep_config.generate_plots,
+                export_csv=prep_config.export_csv,
             )
         n_kin_before = len(df_kin)
         df_kin, network_preprocessing_result = preprocess_networkmodel_frames(

--- a/networkmodel/runner.py
+++ b/networkmodel/runner.py
@@ -198,6 +198,18 @@ def build_parser(config_defaults: dict[str, Any]) -> argparse.ArgumentParser:
                         default=config_defaults["sensitivity"])
     parser.add_argument("--solver", type=str, choices=["jaxopt", "pymoo", "optuna"], default=config_defaults["solver"],
                         help="Choice of optimization solver. Legacy pymoo/optuna values map to jaxopt.")
+    parser.add_argument("--enable-network-preprocessing", action="store_true", default=False,
+                        help="Enable optional pure-JAX hyperedge/network preprocessing before model construction.")
+    parser.add_argument("--network-preprocessing-min-score", type=float, default=0.0,
+                        help="Minimum hyperedge score retained when network preprocessing is enabled.")
+    parser.add_argument("--network-preprocessing-min-support", type=int, default=1,
+                        help="Minimum duplicate/source support retained when network preprocessing is enabled.")
+    parser.add_argument("--network-preprocessing-max-triplets", type=int, default=None,
+                        help="Optional maximum retained triplet count when network preprocessing is enabled.")
+    parser.add_argument("--network-preprocessing-prune-missing-observations", action="store_true", default=False,
+                        help="Prune triplets missing phosphosite or kinase observation support when preprocessing is enabled.")
+    parser.add_argument("--network-preprocessing-keep-self-loops", action="store_true", default=False,
+                        help="Keep kinase self-loop triplets during optional network preprocessing.")
     return parser
 
 
@@ -386,6 +398,7 @@ def main():
     logger.info(f"[Args] Lambda protein: {args.lambda_protein}")
     logger.info(f"[Args] Lambda RNA: {args.lambda_rna}")
     logger.info(f"[Args] Lambda phospho: {args.lambda_phospho}")
+    logger.info(f"[Args] Network preprocessing enabled: {args.enable_network_preprocessing}")
 
     # 1) Load
     df_kin, df_tf, df_prot, df_pho, df_rna, kin_beta_map, tf_beta_map = load_data(args)
@@ -417,6 +430,27 @@ def main():
     df_pho = df_pho.loc[keep].copy()
 
     logger.info(f"[Phospho] Mechanistic site filter: {n_before} → {len(df_pho)} (dropped {n_before - len(df_pho)})")
+
+    if args.enable_network_preprocessing:
+        from network_preprocessing import NetworkPreprocessingConfig, preprocess_networkmodel_frames
+        prep_config = NetworkPreprocessingConfig.from_args(args)
+        if getattr(args, "network_preprocessing_keep_self_loops", False):
+            prep_config = NetworkPreprocessingConfig(
+                min_triplet_score=prep_config.min_triplet_score,
+                min_support_count=prep_config.min_support_count,
+                max_triplets=prep_config.max_triplets,
+                prune_self_loops=False,
+                prune_missing_observations=prep_config.prune_missing_observations,
+            )
+        n_kin_before = len(df_kin)
+        df_kin, network_preprocessing_result = preprocess_networkmodel_frames(
+            df_kin, df_tf, df_prot, df_pho, df_rna,
+            config=prep_config, output_dir=args.output_dir, logger=logger,
+        )
+        logger.info(
+            "[NetworkPreprocessing] Kinase triplets retained: %d → %d",
+            n_kin_before, len(df_kin),
+        )
 
     # -------------------------------------------------------------------------
     # Keep ONLY proteins that are observed in at least one modality (prot/rna/phospho)

--- a/networkmodel/runner.py
+++ b/networkmodel/runner.py
@@ -503,6 +503,11 @@ def main():
             df_kin, df_tf, df_prot, df_pho, df_rna,
             config=prep_config, output_dir=args.output_dir, logger=logger,
         )
+        worker_net_dir = Path(args.output_dir) / "network_preprocessing"
+        worker_net_dir.mkdir(parents=True, exist_ok=True)
+        worker_net_path = worker_net_dir / "pruned_network_for_workers.csv"
+        df_kin.to_csv(worker_net_path, index=False)
+        args.preprocessed_kinase_net = str(worker_net_path)
         logger.info(
             "[NetworkPreprocessing] Kinase triplets retained: %d → %d",
             n_kin_before, len(df_kin),

--- a/tests/test_hyperedge_preprocessing_config.py
+++ b/tests/test_hyperedge_preprocessing_config.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _base_network_config(path: Path, hyperedge_section: str = "") -> None:
+    path.write_text(
+        f'''
+[networkmodel]
+kinase_net = "kin.csv"
+tf_net = "tf.csv"
+ms = "ms.csv"
+rna = "rna.csv"
+output_dir = "out"
+
+{hyperedge_section}
+
+[networkmodel.timepoints]
+protein = [0, 1]
+rna = [0, 1]
+phospho_protein = [0, 1]
+''',
+        encoding="utf-8",
+    )
+
+
+def test_hyperedge_preprocessing_defaults_are_disabled_for_missing_section(tmp_path):
+    pytest.importorskip("numpy")
+    from config_loader import load_config_toml
+
+    conf = tmp_path / "network.toml"
+    _base_network_config(conf)
+
+    cfg = load_config_toml(conf)
+
+    assert cfg.enable_hyperedge_preprocessing is False
+    assert cfg.hyperedge_preprocessing_output_subdir == "network_preprocessing"
+    assert cfg.hyperedge_discovery_threshold == pytest.approx(0.0)
+    assert cfg.hyperedge_pruning_threshold == pytest.approx(0.0)
+    assert cfg.hyperedge_motif_detection is True
+    assert cfg.hyperedge_sparse_tensor_export is True
+    assert cfg.hyperedge_identifiability_preprocessing is True
+    assert cfg.hyperedge_max_triplets is None
+    assert cfg.hyperedge_batch_size == 65536
+    assert cfg.hyperedge_plot_generation is True
+    assert cfg.hyperedge_csv_export is True
+
+
+def test_hyperedge_preprocessing_explicit_enablement_flows_to_runner_defaults(tmp_path):
+    pytest.importorskip("numpy")
+    from config_loader import load_config_toml
+    from networkmodel import runner
+
+    conf = tmp_path / "network.toml"
+    _base_network_config(
+        conf,
+        '''
+[networkmodel.hyperedge_preprocessing]
+enable_hyperedge_preprocessing = true
+output_subdir = "hyperedge_outputs"
+hyperedge_discovery_threshold = 0.2
+hyperedge_pruning_threshold = 0.7
+motif_detection = false
+sparse_tensor_export = false
+identifiability_preprocessing = false
+max_triplets = 25
+batch_size = 128
+plot_generation = false
+csv_export = false
+''',
+    )
+
+    cfg = load_config_toml(conf)
+    assert cfg.enable_hyperedge_preprocessing is True
+    assert cfg.hyperedge_preprocessing_output_subdir == "hyperedge_outputs"
+    assert cfg.hyperedge_discovery_threshold == pytest.approx(0.2)
+    assert cfg.hyperedge_pruning_threshold == pytest.approx(0.7)
+    assert cfg.hyperedge_motif_detection is False
+    assert cfg.hyperedge_sparse_tensor_export is False
+    assert cfg.hyperedge_identifiability_preprocessing is False
+    assert cfg.hyperedge_max_triplets == 25
+    assert cfg.hyperedge_batch_size == 128
+    assert cfg.hyperedge_plot_generation is False
+    assert cfg.hyperedge_csv_export is False
+
+    args, _ = runner.parse_runtime_args(["--conf", str(conf)])
+    assert args.enable_network_preprocessing is True
+    assert args.network_preprocessing_output_subdir == "hyperedge_outputs"
+    assert args.network_preprocessing_min_score == pytest.approx(0.7)
+    assert args.network_preprocessing_max_triplets == 25
+    assert args.network_preprocessing_batch_size == 128
+    assert args.network_preprocessing_enable_motifs is False
+    assert args.network_preprocessing_export_sparse_tensor is False
+    assert args.network_preprocessing_generate_plots is False
+    assert args.network_preprocessing_export_csv is False
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("hyperedge_discovery_threshold", "-0.1", "hyperedge_discovery_threshold must be non-negative"),
+        ("hyperedge_pruning_threshold", "-0.1", "hyperedge_pruning_threshold must be non-negative"),
+        ("max_triplets", "-1", "max_triplets must be non-negative"),
+        ("batch_size", "0", "batch_size must be positive"),
+    ],
+)
+def test_hyperedge_preprocessing_invalid_values_raise_clear_errors(tmp_path, field, value, message):
+    pytest.importorskip("numpy")
+    from config_loader import load_config_toml
+
+    conf = tmp_path / "network.toml"
+    _base_network_config(
+        conf,
+        f'''
+[networkmodel.hyperedge_preprocessing]
+{field} = {value}
+''',
+    )
+
+    with pytest.raises(ValueError, match=message):
+        load_config_toml(conf)

--- a/tests/test_network_preprocessing.py
+++ b/tests/test_network_preprocessing.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+import jax
+import jax.numpy as jnp
+import pandas as pd
+from network_preprocessing import NetworkPreprocessingConfig, preprocess_network
+from network_preprocessing.jax_kernels import score_triplets
+
+
+def frames():
+    kin=pd.DataFrame({"protein":["B","C","C","D","A"],"psite":["S1","S2","S2","S3","S4"],"kinase":["A","B","A","D","A"],"alpha":[1.0,2.0,1.5,1.0,0.1]})
+    pho=pd.DataFrame({"protein":["B","C","D"],"psite":["S1","S2","S3"],"time":[0,0,0],"fc":[1,1,1]})
+    prot=pd.DataFrame({"protein":["A","B","D"],"time":[0,0,0],"fc":[1,1,1]})
+    return kin,pho,prot
+
+
+def test_hyperedge_discovery_and_float64_jit():
+    kin,pho,prot=frames()
+    res=preprocess_network(kin, phospho_observations=pho, protein_observations=prot, config=NetworkPreprocessingConfig(prune_self_loops=False))
+    assert res.summary["n_discovered"] == 5
+    assert res.discovered.score.dtype == jnp.float64
+    lowered=score_triplets.lower(res.encoded.edge_weight, res.encoded.support_count, res.encoded.site_observed, res.encoded.kinase_observed, res.encoded.kinase_ids, res.encoded.substrate_ids)
+    assert lowered.compile() is not None
+    assert jax.config.jax_enable_x64
+
+
+def test_pruning_behavior_and_sparse_tensor_validity():
+    kin,pho,prot=frames()
+    res=preprocess_network(kin, phospho_observations=pho, protein_observations=prot, config=NetworkPreprocessingConfig(prune_self_loops=True, prune_missing_observations=True, min_support_count=1))
+    assert res.summary["n_retained"] < res.summary["n_discovered"]
+    assert res.theta.indices.shape == (res.summary["n_retained"], 3)
+    assert res.theta.indices.dtype == jnp.int32
+    assert res.theta.values.dtype == jnp.float64
+    if res.theta.indices.size:
+        assert int(res.theta.indices[:,0].max()) < res.theta.shape[0]
+        assert int(res.theta.indices[:,1].max()) < res.theta.shape[1]
+        assert int(res.theta.indices[:,2].max()) < res.theta.shape[2]
+
+
+def test_motif_detection_correctness():
+    kin=pd.DataFrame({"protein":["B","C","C"],"psite":["S1","S2","S3"],"kinase":["A","B","A"],"alpha":[1,1,1]})
+    res=preprocess_network(kin, config=NetworkPreprocessingConfig(prune_self_loops=False))
+    assert res.summary["n_motifs"] >= 1
+    assert set(map(int, res.motifs.motif_type.tolist())) == {1}
+
+
+def test_identifiability_and_outputs(tmp_path):
+    kin,pho,prot=frames()
+    res=preprocess_network(kin, phospho_observations=pho, protein_observations=prot, output_dir=tmp_path, config=NetworkPreprocessingConfig(prune_self_loops=False))
+    assert res.identifiability.retained_param_mask.shape[0] == res.theta.values.shape[0]
+    assert (tmp_path/"tables"/"network_preprocessing"/"discovered_hyperedges.csv").is_file()
+    assert (tmp_path/"tables"/"network_preprocessing"/"retained_triplets.csv").is_file()
+    assert (tmp_path/"tables"/"network_preprocessing"/"sparse_theta_indices_values.csv").is_file()
+    assert (tmp_path/"plots"/"network_preprocessing"/"hyperedge_score_distribution.png").is_file()
+    assert (tmp_path/"plots"/"network_preprocessing"/"identifiability_diagnostics.png").is_file()
+
+
+def test_runner_parser_disabled_by_default():
+    from networkmodel.runner import _config_defaults, build_parser
+    class C:
+        kinase_net=tf_net=ms_data=rna_data=phospho_data=kinopt_results=tfopt_results="x.csv"; results_dir="out"; cores=1; maximum_iterations=1; seed=1; regularization_lambda=regularization_protein=regularization_rna=regularization_phospho=0.0; normalize_fc_steady=False; use_initial_condition_from_data=False; hyperparam_scan=False; sensitivity_analysis=False; time_points_prot=(0,); time_points_rna=(0,); time_points_phospho=(0,)
+    p=build_parser(_config_defaults(C(), Path('config.toml'), None))
+    args=p.parse_args([])
+    assert args.enable_network_preprocessing is False
+    args=p.parse_args(["--enable-network-preprocessing"])
+    assert args.enable_network_preprocessing is True

--- a/tests/test_network_preprocessing.py
+++ b/tests/test_network_preprocessing.py
@@ -43,6 +43,31 @@ def test_motif_detection_correctness():
     assert set(map(int, res.motifs.motif_type.tolist())) == {1}
 
 
+def test_motif_detection_uses_common_node_namespace_false_positive_regression():
+    kin = pd.DataFrame({
+        "protein": ["C", "D", "D"],
+        "psite": ["S1", "S2", "S3"],
+        "kinase": ["A", "X", "A"],
+        "alpha": [1.0, 1.0, 1.0],
+    })
+    res = preprocess_network(kin, config=NetworkPreprocessingConfig(prune_self_loops=False))
+    assert res.summary["n_motifs"] == 0
+
+
+def test_motif_detection_uses_common_node_namespace_positive_control():
+    kin = pd.DataFrame({
+        "protein": ["X", "D", "D"],
+        "psite": ["S1", "S2", "S3"],
+        "kinase": ["A", "X", "A"],
+        "alpha": [1.0, 1.0, 1.0],
+    })
+    res = preprocess_network(kin, config=NetworkPreprocessingConfig(prune_self_loops=False))
+    assert res.summary["n_motifs"] == 1
+    motif = res.motifs
+    labels = motif.node_labels
+    assert (labels[int(motif.node_a[0])], labels[int(motif.node_b[0])], labels[int(motif.node_c[0])]) == ("A", "X", "D")
+
+
 def test_identifiability_and_outputs(tmp_path):
     kin,pho,prot=frames()
     res=preprocess_network(kin, phospho_observations=pho, protein_observations=prot, output_dir=tmp_path, config=NetworkPreprocessingConfig(prune_self_loops=False))

--- a/tests/test_network_preprocessing.py
+++ b/tests/test_network_preprocessing.py
@@ -3,7 +3,7 @@ import jax
 import jax.numpy as jnp
 import pandas as pd
 from network_preprocessing import NetworkPreprocessingConfig, preprocess_network, preprocess_networkmodel_frames
-from network_preprocessing.jax_kernels import score_triplets
+from network_preprocessing.jax_kernels import identifiability_kernel, score_triplets
 
 
 def frames():
@@ -98,6 +98,37 @@ def test_motif_detection_uses_common_node_namespace_positive_control():
     motif = res.motifs
     labels = motif.node_labels
     assert (labels[int(motif.node_a[0])], labels[int(motif.node_b[0])], labels[int(motif.node_c[0])]) == ("A", "X", "D")
+
+
+def test_identifiability_grouping_avoids_legacy_linear_hash_collision():
+    indices = jnp.asarray([[1, 0, 0], [0, 991, 84]], dtype=jnp.int32)
+    values = jnp.ones(2, dtype=jnp.float64)
+
+    _, group_id, _, _ = identifiability_kernel(indices, values)
+
+    assert int(group_id[0]) != int(group_id[1])
+
+
+def test_identifiability_grouping_keeps_duplicate_triplets_together():
+    indices = jnp.asarray([[2, 3, 4], [2, 3, 4], [2, 3, 5]], dtype=jnp.int32)
+    values = jnp.ones(3, dtype=jnp.float64)
+
+    _, group_id, _, _ = identifiability_kernel(indices, values)
+
+    assert int(group_id[0]) == int(group_id[1])
+    assert int(group_id[0]) != int(group_id[2])
+
+
+def test_identifiability_grouping_large_sparse_tensor_is_deterministic():
+    indices = jnp.asarray([[1, 0, 0], [0, 991, 84], [7, 1200, 99], [7, 1200, 99]], dtype=jnp.int32)
+    values = jnp.ones(4, dtype=jnp.float64)
+
+    _, group_id_a, _, _ = identifiability_kernel(indices, values)
+    _, group_id_b, _, _ = identifiability_kernel(indices, values)
+
+    assert group_id_a.tolist() == group_id_b.tolist()
+    assert int(group_id_a[0]) != int(group_id_a[1])
+    assert int(group_id_a[2]) == int(group_id_a[3])
 
 
 def test_identifiability_and_outputs(tmp_path):

--- a/tests/test_network_preprocessing.py
+++ b/tests/test_network_preprocessing.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import jax
 import jax.numpy as jnp
 import pandas as pd
-from network_preprocessing import NetworkPreprocessingConfig, preprocess_network
+from network_preprocessing import NetworkPreprocessingConfig, preprocess_network, preprocess_networkmodel_frames
 from network_preprocessing.jax_kernels import score_triplets
 
 
@@ -109,6 +109,72 @@ def test_identifiability_and_outputs(tmp_path):
     assert (tmp_path/"tables"/"network_preprocessing"/"sparse_theta_indices_values.csv").is_file()
     assert (tmp_path/"plots"/"network_preprocessing"/"hyperedge_score_distribution.png").is_file()
     assert (tmp_path/"plots"/"network_preprocessing"/"identifiability_diagnostics.png").is_file()
+
+
+def test_networkmodel_preprocessing_collapses_duplicate_retained_triplets():
+    kin = pd.DataFrame({
+        "protein": ["B", "B", "C"],
+        "psite": ["S1", "S1", "S2"],
+        "kinase": ["A", "A", "X"],
+        "alpha": [0.2, 0.9, 0.5],
+    })
+    pruned_df, res = preprocess_networkmodel_frames(
+        kin, pd.DataFrame(), pd.DataFrame(), pd.DataFrame(), pd.DataFrame(),
+        config=NetworkPreprocessingConfig(prune_self_loops=False, enable_motifs=False),
+    )
+
+    dup = pruned_df[(pruned_df["kinase"] == "A") & (pruned_df["protein"] == "B") & (pruned_df["psite"] == "S1")]
+    assert len(dup) == 1
+    assert dup["alpha"].iloc[0] == 0.9
+    assert dup["support_count"].iloc[0] == 2
+    assert pruned_df[["kinase", "protein", "psite"]].duplicated().sum() == 0
+    assert int(res.pruned.support_count.max()) == 2
+
+
+def test_pruned_worker_csv_matches_retained_triplet_diagnostics(tmp_path):
+    kin = pd.DataFrame({
+        "protein": ["B", "B", "C"],
+        "psite": ["S1", "S1", "S2"],
+        "kinase": ["A", "A", "X"],
+        "alpha": [0.2, 0.9, 0.5],
+    })
+    pruned_df, _ = preprocess_networkmodel_frames(
+        kin, pd.DataFrame(), pd.DataFrame(), pd.DataFrame(), pd.DataFrame(),
+        config=NetworkPreprocessingConfig(prune_self_loops=False, enable_motifs=False),
+        output_dir=tmp_path,
+    )
+    worker_csv = tmp_path / "network_preprocessing" / "pruned_network_for_workers.csv"
+    worker_csv.parent.mkdir(parents=True)
+    pruned_df.to_csv(worker_csv, index=False)
+
+    retained = pd.read_csv(tmp_path / "tables" / "network_preprocessing" / "retained_triplets.csv")
+    retained_keys = retained.assign(
+        protein=retained["site"].str.split(":", n=1).str[0],
+        psite=retained["site"].str.split(":", n=1).str[1],
+    )[["kinase", "protein", "psite", "alpha"]].sort_values(["kinase", "protein", "psite"]).reset_index(drop=True)
+    worker_keys = pd.read_csv(worker_csv)[["kinase", "protein", "psite", "alpha"]].sort_values(["kinase", "protein", "psite"]).reset_index(drop=True)
+
+    pd.testing.assert_frame_equal(worker_keys, retained_keys)
+
+
+def test_networkmodel_preprocessing_nonduplicate_input_preserves_rows():
+    kin = pd.DataFrame({
+        "protein": ["B", "C"],
+        "psite": ["S1", "S2"],
+        "kinase": ["A", "X"],
+        "alpha": [0.2, 0.5],
+    })
+    pruned_df, _ = preprocess_networkmodel_frames(
+        kin, pd.DataFrame(), pd.DataFrame(), pd.DataFrame(), pd.DataFrame(),
+        config=NetworkPreprocessingConfig(prune_self_loops=False, enable_motifs=False),
+    )
+
+    expected = kin.assign(support_count=1)
+    pd.testing.assert_frame_equal(
+        pruned_df.sort_values(["kinase", "protein", "psite"]).reset_index(drop=True),
+        expected.sort_values(["kinase", "protein", "psite"]).reset_index(drop=True),
+        check_dtype=False,
+    )
 
 
 def test_runner_parser_disabled_by_default():

--- a/tests/test_network_preprocessing.py
+++ b/tests/test_network_preprocessing.py
@@ -18,7 +18,7 @@ def test_hyperedge_discovery_and_float64_jit():
     res=preprocess_network(kin, phospho_observations=pho, protein_observations=prot, config=NetworkPreprocessingConfig(prune_self_loops=False))
     assert res.summary["n_discovered"] == 5
     assert res.discovered.score.dtype == jnp.float64
-    lowered=score_triplets.lower(res.encoded.edge_weight, res.encoded.support_count, res.encoded.site_observed, res.encoded.kinase_observed, res.encoded.kinase_ids, res.encoded.substrate_ids)
+    lowered=score_triplets.lower(res.encoded.edge_weight, res.encoded.support_count, res.encoded.site_observed, res.encoded.kinase_observed, res.encoded.kinase_node_ids, res.encoded.substrate_node_ids)
     assert lowered.compile() is not None
     assert jax.config.jax_enable_x64
 
@@ -34,6 +34,38 @@ def test_pruning_behavior_and_sparse_tensor_validity():
         assert int(res.theta.indices[:,0].max()) < res.theta.shape[0]
         assert int(res.theta.indices[:,1].max()) < res.theta.shape[1]
         assert int(res.theta.indices[:,2].max()) < res.theta.shape[2]
+
+
+def test_self_loop_penalty_uses_common_node_namespace():
+    non_loop = pd.DataFrame({
+        "protein": ["B", "C"],
+        "psite": ["S1", "S2"],
+        "kinase": ["A", "X"],
+        "alpha": [1.0, 1.0],
+    })
+    non_loop_res = preprocess_network(non_loop, config=NetworkPreprocessingConfig(prune_self_loops=False, enable_motifs=False))
+    expected_without_penalty = jnp.log1p(jnp.float64(1.0)) + 0.5 * jnp.log1p(jnp.float64(1.0))
+    assert float(non_loop_res.discovered.score[0]) == float(expected_without_penalty)
+
+    true_loop = pd.DataFrame({
+        "protein": ["A"],
+        "psite": ["S1"],
+        "kinase": ["A"],
+        "alpha": [1.0],
+    })
+    loop_res = preprocess_network(true_loop, config=NetworkPreprocessingConfig(prune_self_loops=False, enable_motifs=False))
+    assert float(loop_res.discovered.score[0]) == float(expected_without_penalty - 0.5)
+
+
+def test_cli_max_triplets_zero_normalizes_to_none():
+    from argparse import Namespace
+
+    cfg = NetworkPreprocessingConfig.from_args(Namespace(network_preprocessing_max_triplets=0))
+    assert cfg.max_triplets is None
+
+    kin, pho, prot = frames()
+    res = preprocess_network(kin, phospho_observations=pho, protein_observations=prot, config=cfg)
+    assert res.summary["n_retained"] > 0
 
 
 def test_motif_detection_correctness():

--- a/tests/test_networkmodel_inference_workers.py
+++ b/tests/test_networkmodel_inference_workers.py
@@ -10,6 +10,7 @@ import pytest
 
 import networkmodel.BayesianInference as bi
 from networkmodel.BayesianInference import InferenceContext
+import networkmodel.PosteriorObjective as po
 from networkmodel.PosteriorObjective import write_posterior_payload
 from networkmodel.backend import DataMode
 from networkmodel.sensitivity import compute_bounds
@@ -187,7 +188,88 @@ def test_write_posterior_payload_writes_arrays_names_and_run_config(tmp_path):
     data = json.loads(path.read_text())
     assert data["output_dir"] == str(tmp_path)
     assert data["payload_dir"] == str(payload_dir)
+    assert "preprocessed_kinase_net" not in data
     assert data["lambdas"] == {"protein": 1.0, "rna": 2.0, "phospho": 3.0, "prior": 4.0}
+
+
+def test_posterior_payload_includes_preprocessed_network_path(tmp_path):
+    ctx = _ctx(tmp_path)
+    pruned = tmp_path / "network_preprocessing" / "pruned_network_for_workers.csv"
+    pruned.parent.mkdir()
+    pruned.write_text("protein,psite,kinase,alpha\nB,S1,A,1.0\n", encoding="utf-8")
+    args = SimpleNamespace(
+        kinase_net="original.csv", tf_net="tf.csv", ms="ms.csv", rna="rna.csv",
+        phospho="phospho.csv", kinopt="", tfopt="", cores=1, n_gen=1, seed=1,
+        normalize_fc_steady=False, use_initial_condition_from_data=False,
+        preprocessed_kinase_net=str(pruned),
+    )
+
+    path = write_posterior_payload(
+        ctx=ctx, runner_args=args,
+        lambdas={"protein": 1, "rna": 1, "phospho": 1, "prior": 1},
+        output_dir=tmp_path,
+    )
+
+    data = json.loads(path.read_text())
+    assert data["kinase_net"] == "original.csv"
+    assert data["preprocessed_kinase_net"] == str(pruned)
+
+
+def test_posterior_worker_loads_preprocessed_network_instead_of_original(tmp_path, monkeypatch):
+    original = pd.DataFrame({
+        "protein": ["B", "C"],
+        "psite": ["S1", "S2"],
+        "kinase": ["A", "X"],
+        "alpha": [1.0, 1.0],
+    })
+    pruned = pd.DataFrame({"protein": ["B"], "psite": ["S1"], "kinase": ["A"], "alpha": [1.0]})
+    pruned_path = tmp_path / "pruned_network_for_workers.csv"
+    pruned.to_csv(pruned_path, index=False)
+
+    def fake_load_data(args):
+        return original.copy(), pd.DataFrame(columns=["tf", "target", "alpha"]), pd.DataFrame(), pd.DataFrame(columns=["protein", "psite"]), pd.DataFrame(), {}, {}
+
+    monkeypatch.setattr(po, "load_data", fake_load_data)
+    args = SimpleNamespace(kinase_net="original.csv")
+    loaded = po._load_data_for_posterior_context(args, {"preprocessed_kinase_net": str(pruned_path)})
+
+    assert loaded[0].reset_index(drop=True).equals(pruned)
+
+
+def test_posterior_worker_uses_original_network_without_preprocessed_path(monkeypatch):
+    original = pd.DataFrame({"protein": ["B"], "psite": ["S1"], "kinase": ["A"], "alpha": [1.0]})
+
+    def fake_load_data(args):
+        return original.copy(), pd.DataFrame(), pd.DataFrame(), pd.DataFrame(), pd.DataFrame(), {}, {}
+
+    monkeypatch.setattr(po, "load_data", fake_load_data)
+    loaded = po._load_data_for_posterior_context(SimpleNamespace(kinase_net="original.csv"), {})
+
+    assert loaded[0].equals(original)
+
+
+def test_posterior_worker_pruned_network_shape_matches_main_pruned_network(tmp_path, monkeypatch):
+    original = pd.DataFrame({
+        "protein": ["B", "C"],
+        "psite": ["S1", "S2"],
+        "kinase": ["A", "X"],
+        "alpha": [1.0, 1.0],
+    })
+    main_pruned = original.iloc[[0]].copy().reset_index(drop=True)
+    pruned_path = tmp_path / "pruned_network_for_workers.csv"
+    main_pruned.to_csv(pruned_path, index=False)
+
+    def fake_load_data(args):
+        return original.copy(), pd.DataFrame(), pd.DataFrame(), pd.DataFrame(columns=["protein", "psite"]), pd.DataFrame(), {}, {}
+
+    monkeypatch.setattr(po, "load_data", fake_load_data)
+    worker_df_kin = po._load_data_for_posterior_context(
+        SimpleNamespace(kinase_net="original.csv"),
+        {"preprocessed_kinase_net": str(pruned_path)},
+    )[0]
+
+    assert worker_df_kin.shape == main_pruned.shape
+    assert worker_df_kin.reset_index(drop=True).equals(main_pruned)
 
 
 def test_param_names_pad_truncate_and_generate_defaults():


### PR DESCRIPTION
### Motivation
- Implement the independent, optional pure-JAX hyperedge/network-preprocessing pipeline described in `docs/jax_hyperedge_network_preprocessing.md` to run between data loading and model construction without changing default workflows. 
- Provide JAX-native computational kernels (score/prune/identifiability/motif/tensor construction) that respect `float64` and are suitable for later JAXopt integration. 
- Export labeled diagnostics and plots into the standard run result directory and expose a minimal, disabled-by-default integration hook into the existing `networkmodel.runner` CLI.

### Description
- Added a new top-level package `network_preprocessing` implementing dataclasses, I/O adapters, JAX kernels, scoring/pruning/motif/identifiability APIs, CSV/NPZ exports, and plotting: `network_preprocessing/{dataclasses.py,io_adapters.py,jax_kernels.py,api.py,export.py,plotting.py,__init__.py}`. 
- Core numerical work is implemented in `network_preprocessing/jax_kernels.py` using `jax.jit`, `jax.numpy` and explicitly enabling `jax_enable_x64` to keep float64 behavior. 
- Host/I-O boundary adapters convert `pandas` frames to JAX arrays in `io_adapters.py`, build a COO-like sparse theta (`indices`, `values`, `shape`) in `api.py`, and write labelled CSV/NPZ/JSON artifacts via `export.py` and publication-quality PNGs via `plotting.py`. 
- Integrated as an optional hook in `networkmodel.runner` behind new CLI flags (disabled by default): `--enable-network-preprocessing` plus scoped flags such as `--network-preprocessing-min-score`, `--network-preprocessing-min-support`, `--network-preprocessing-max-triplets`, `--network-preprocessing-prune-missing-observations`, and `--network-preprocessing-keep-self-loops`. 

### Testing
- Byte-compile smoke: `python -m py_compile network_preprocessing/*.py networkmodel/runner.py` completed successfully. 
- Unit/test run: `pytest -q tests/test_network_preprocessing.py` was attempted but the environment lacks the `jax` package and collection failed with `ModuleNotFoundError: No module named 'jax'`; with `jax` present the added tests exercise discovery, pruning, motif detection, sparse tensor shape/dtypes, identifiability diagnostics, JIT/float64 expectations, CSV/plot exports, and the runner CLI flag behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a352bbb929883279d9b0fa3722c970d)